### PR TITLE
Add instructions and minor code changes to build on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,13 +41,28 @@ include(options)
 ## Pull in common cflags setting from leatherman. Don't override CMAKE_CXX_FLAGS at the project root to avoid impacting 3rd party code.
 include(cflags)
 set(${PROJECT_NAME_UPPER}_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS}")
+
+# On OS X, git_t is an unsigned int, though signed int on most other platforms
+if (APPLE)
+    list(APPEND LEATHERMAN_DEFINITIONS -DHAVE_UNSIGNED_GID_T)
+endif()
+
 add_definitions(${LEATHERMAN_DEFINITIONS})
+
 ## Pull in helper macros for working with leatherman libraries
 include(leatherman)
 
 # Add other dependencies
 set(Boost_USE_STATIC_LIBS ${LIBRAL_STATIC})
 find_package(Boost 1.54 REQUIRED COMPONENTS program_options)
+
+find_package(LibXml2 REQUIRED)
+if ("${LIBXML2_INCLUDE_DIRS}" STREQUAL "")
+    find_path(LIBXML2_INCLUDE_DIRS libxml/tree.h PATH_SUFFIXES libxml2)
+    if ("${LIBXML2_INCLUDE_DIRS}" STREQUAL "LIBXML2_INCLUDE_DIRS-NOTFOUND")
+        message(FATAL_ERROR "LibXml2 was not found")
+    endif()
+endif()
 
 set(AUGEAS_STATIC ${LIBRAL_STATIC})
 find_package(Augeas REQUIRED)

--- a/HACKING.md
+++ b/HACKING.md
@@ -100,3 +100,40 @@ Assuming you have that toolchain, you need to do the following:
     # into VM's or containers
     ../examples/dpack
 ```
+
+## Building on OS X
+
+Libral builds successfully with Clang 5.0+ and libraries installed with the
+[Homebrew](https://brew.sh) package manager.
+
+### Install packages (homebrew)
+
+```bash
+    brew install cmake boost openssl libxml2 yaml-cpp augeas
+```
+
+### Build Leatherman
+
+Follow the same instructions as building on Linux.
+
+```bash
+    git clone https://github.com/puppetlabs/leatherman.git
+    cd leatherman
+    git checkout 0.10.1
+    mkdir build && cd build
+    cmake ..
+    make
+    sudo make install
+```
+
+### Build libral
+
+Again, following the same instructions as Linux.
+
+```bash
+    git clone https://github.com/puppetlabs/libral
+    cd libral
+    mkdir build && cd build
+    cmake ..
+    make
+```

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(
     ../lib/inc
     ${PROJECT_BINARY_DIR}/inc
     ${Boost_INCLUDE_DIRS}
+    ${LIBXML2_INCLUDE_DIRS}
     ${LEATHERMAN_INCLUDE_DIRS}
 )
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ include_directories(
   ${AUGEAS_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
   ${YAMLCPP_INCLUDE_DIRS}
+  ${LIBXML2_INCLUDE_DIRS}
   ${LEATHERMAN_INCLUDE_DIRS})
 
 link_directories(

--- a/lib/inc/libral/augeas.hpp
+++ b/lib/inc/libral/augeas.hpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include <vector>
 #include <memory>
+#include <string>
 #include <boost/optional.hpp>
 
 #include <augeas.h>

--- a/lib/inc/libral/file.hpp
+++ b/lib/inc/libral/file.hpp
@@ -79,14 +79,14 @@ namespace libral {
       shared_provider_ptr _prov;
     };
 
-    result<bool> suitable() { return true; };
+    result<bool> suitable() override { return true; };
 
     /* Always returns an empty vector for now, can't list all files this
        way. The API is missing a way to indicate an error from instances */
     result<std::vector<resource_uptr>> instances() override;
     result<boost::optional<resource_uptr>> find(const std::string &name) override;
 
-    std::unique_ptr<resource> create(const std::string& name);
+    std::unique_ptr<resource> create(const std::string& name) override;
   protected:
     result<prov::spec> describe() override;
   private:

--- a/lib/inc/libral/json_provider.hpp
+++ b/lib/inc/libral/json_provider.hpp
@@ -27,13 +27,13 @@ namespace libral {
     json_provider(const std::string& path, YAML::Node &node)
       : provider(), _path(path), _node(node) { };
 
-    result<bool> suitable();
-    void flush();
-    std::unique_ptr<resource> create(const std::string& name);
+    result<bool> suitable() override;
+    void flush() override;
+    std::unique_ptr<resource> create(const std::string& name) override;
     result<boost::optional<resource_uptr>> find(const std::string &name) override;
     result<std::vector<resource_uptr>> instances() override;
 
-    const std::string& source() const { return _path; }
+    const std::string& source() const override { return _path; }
   protected:
     result<prov::spec> describe() override;
   private:

--- a/lib/inc/libral/mount.hpp
+++ b/lib/inc/libral/mount.hpp
@@ -64,10 +64,10 @@ namespace libral {
     mount_provider(std::shared_ptr<ral> ral)
       : aug(nullptr), _ral(ral), _seq(1) { };
 
-    result<bool> suitable();
-    void flush();
+    result<bool> suitable() override;
+    void flush() override;
     result<std::vector<resource_uptr>> instances() override;
-    resource_uptr create(const std::string& name);
+    resource_uptr create(const std::string& name) override;
   protected:
     result<prov::spec> describe() override;
   private:

--- a/lib/inc/libral/simple_provider.hpp
+++ b/lib/inc/libral/simple_provider.hpp
@@ -25,13 +25,13 @@ namespace libral {
     simple_provider(const std::string& path, YAML::Node &node)
       : provider(), _path(path), _node(node) { };
 
-    result<bool> suitable();
-    void flush();
-    std::unique_ptr<resource> create(const std::string& name);
+    result<bool> suitable() override;
+    void flush() override;
+    std::unique_ptr<resource> create(const std::string& name) override;
     result<boost::optional<resource_uptr>> find(const std::string &name) override;
     result<std::vector<resource_uptr>> instances() override;
 
-    const std::string& source() const { return _path; }
+    const std::string& source() const override { return _path; }
   protected:
     result<prov::spec> describe() override;
   private:

--- a/lib/inc/libral/user.hpp
+++ b/lib/inc/libral/user.hpp
@@ -63,10 +63,10 @@ namespace libral {
     };
 
     const std::string& description();
-    result<bool> suitable();
-    void flush();
+    result<bool> suitable() override;
+    void flush() override;
     result<std::vector<resource_uptr>> instances() override;
-    std::unique_ptr<resource> create(const std::string& name);
+    std::unique_ptr<resource> create(const std::string& name) override;
   protected:
     result<prov::spec> describe() override;
   private:

--- a/lib/src/ral.cc
+++ b/lib/src/ral.cc
@@ -36,7 +36,7 @@ namespace libral {
         res = prov->prepare();
         if (res && *res) {
           auto t = new type(name, prov);
-          types.push_back(std::move(std::unique_ptr<type>(t)));
+          types.push_back(std::unique_ptr<type>(t));
           return true;
         } else {
           LOG_ERROR("provider[{1}]: preparing failed: {2}",

--- a/lib/src/user.cc
+++ b/lib/src/user.cc
@@ -8,6 +8,13 @@
 
 #include <stdlib.h>
 
+#ifndef HAVE_UNSIGNED_GID_T
+typedef gid_t getgroups_t;
+#else
+// Group list argument to getgrouplist() is a signed int (not gid_t) on OS X
+typedef int getgroups_t;
+#endif
+
 using namespace leatherman::locale;
 
 namespace libral {
@@ -33,9 +40,9 @@ namespace libral {
   static result<bool> add_group_list(resource& rsrc,
                                      const char* user, gid_t group) {
     int ngroups = 0;
-    gid_t *groups = nullptr;
+    getgroups_t *groups = nullptr;
     getgrouplist(user, group, nullptr, &ngroups);
-    groups = new gid_t[ngroups];
+    groups = new getgroups_t[ngroups];
     getgrouplist(user, group, groups, &ngroups);
     auto group_names = array();
     for (int i=0; i < ngroups; i++) {


### PR DESCRIPTION
Work in progress: This allows libral to build on OS X, but the resulting ralsh executable does not fully work yet on OS X.

$ ./bin/ralsh mount
libc++abi.dylib: terminating with uncaught exception of type aug::error: Lens not found

Can not find lens Mount_Fstab.lns
Abort trap: 6
