### PR TITLE
First cut at producing JSON output from ralsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ you can try things out by running `ralsh`:
     ralsh service crond ensure=stopped
 ```
 
+The default output from `ralsh` is meant for human consumption and looks a
+lot like Puppet. It is also possible to have `ralsh` produce
+[JSON output](doc/ralsh-json-output.md) by passing the `--json` flag.
+
 Many of the providers that `libral` knows about are separate
 scripts. `ralsh` searches them in the following order. In each case, the
 providers must be executable scripts in a subdirectory `providers` in the

--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -10,6 +10,14 @@ must be of type `string`. This attribute can not be changed through
 `update`. It serves as a primary key for the resource among all the
 resources managed by a specific provider.
 
+If the provider can create and/or delete resources, the attribute
+controlling that must be called `ensure` and must accept, at a minumum, the
+values `present` (create if not existent) and `absent` (delete if it
+already exists)
+
+The attribute names `ral` and any names starting with `ral_` and `__` (two
+underscores) are reserved, and must not be used as attribute names.
+
 ## Specifying provider attributes
 
 Provider attributes are specified in the YAML metadata that the `describe`

--- a/doc/ralsh-json-output.md
+++ b/doc/ralsh-json-output.md
@@ -1,0 +1,142 @@
+# Format of ralsh's JSON output
+
+When you run `ralsh --json`, it will produce JSON output meant for use by
+other tools and programs. This page describes what you can find in that
+output.
+
+## Provider listing
+
+When you run `ralsh --json`, it produces a list of the providers it knows
+about. The output object contains one key `providers` whose content is an
+array of objects, each object describing one provider. The description of a
+provider has the following fields:
+
+* `name`: the qualified name of the provider
+* `type`: the name of the type to which this provider belongs
+* `source`: the source for the provider, either `builtin` for C++ providers
+  or the path of the provider script for external providers
+* `suitable`: a boolean indicating whether the provider can be used on this
+  system; curently, this will always be `true` as unsuitable providers are
+  not loaded by `ralsh` (though that might change in the future)
+* `attributes`: an array of objects describing each of the provider's
+  attributes, containing the `name`, `desc`, `type`, and `kind` for the
+  attribute as detailed in the [resource attributes](./attributes.md)
+  specification
+
+An example of this output looks like
+```json
+{
+  "providers": [
+    {
+      "name": "service::sysv",
+      "type": "service",
+      "source": "/usr/share/libral/data/providers/sysv.prov",
+      "suitable": true,
+      "desc": "",
+      "attributes": [
+        {
+          "kind": "rw",
+          "type": "enum[true, false]",
+          "desc": "(missing description)",
+          "name": "enable"
+        },
+        {
+          "kind": "rw",
+          "type": "enum[running, stopped]",
+          "desc": "(missing description)",
+          "name": "ensure"
+        },
+        {
+          "kind": "rw",
+          "type": "string",
+          "desc": "(missing description)",
+          "name": "name"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Resource listing
+
+When you run `ralsh --json <PROVIDER>`, ralsh prints a list of all
+resources managed by `PROVIDER`. The output object contains one key
+`resources` whose content is an array of objects, each object describing
+one resource. Those objects have the following fields:
+
+* one field for each attribute, using the attribute's name as the key and
+  the attribute's value as the value
+* a field `ral` carrying an object with some metainformation; currently
+  that object contains the entries `type` with the resource's type, and
+  `provider` with the fully-qualified name of the provider.
+
+## Resource find
+
+When you run `ralsh --json <PROVIDER> <NAME>`, ralsh prints the resource
+`NAME` managed by `PROVIDER`. The output object contains one key `resource`
+whose content is that resource, in the same format as that used when
+listing resources.
+
+An example of this output looks like
+```json
+{
+  "resource": {
+    "ral": {
+      "provider": "service::sysv",
+      "type": "service"
+    },
+    "ensure": "stopped",
+    "enable": "false",
+    "name": "smartd"
+  }
+}
+```
+
+**NOTE**: it's silly to have a different output format. Maybe this should
+just return a `resources` array with a single resource in it.
+
+## Resource update
+
+When you run `ralsh --json <PROVIDER> <NAME> A1=V1 A2=V2`, ralsh prints the
+result of ensuring that the resource `NAME` managed by `PROVIDER` is in the
+desired state expressed by the `An=Vn` attribute changes. The output object
+contains two keys:
+
+* `resource` showing the state after the changes have been made, in the
+  same format as is used when finding a resource
+* `changes`, an array detailing the changes that had to be made to each
+  attribute to bring the resource into that state. Only attributes that had
+  to be changed are listed here. Each entry in the array
+  is an object with these keys:
+  * `attr`: the name of the attribute that was changed
+  * `is`: the current state of the attribute, i.e., the state it is in
+    after the change
+  * `was`: the previous state of the attribute, i.e., the state it was in
+    before the change
+
+An example of this output looks like
+```json
+{
+  "changes": [
+    {
+      "was": "stopped",
+      "is": "running",
+      "attr": "ensure"
+    }
+  ],
+  "resource": {
+    "ral": {
+      "provider": "service::sysv",
+      "type": "service"
+    },
+    "ensure": "running",
+    "enable": "false",
+    "name": "smartd"
+  }
+}
+```
+**NOTE**: it is likely that this format will be changed to an array of
+   `changes`/`resource` pairs to accomodate providers where enforcing the
+   state of one resource actually touches many resources (like recursive
+   file operations)

--- a/exe/ralsh.cc
+++ b/exe/ralsh.cc
@@ -6,6 +6,7 @@
 #include <leatherman/util/environment.hpp>
 
 #include <libral/emitter/puppet_emitter.hpp>
+#include <libral/emitter/json_emitter.hpp>
 
 #include <iomanip>
 
@@ -131,6 +132,7 @@ int main(int argc, char **argv) {
       ("help,h", "produce help message")
       ("include,I", po::value<std::vector<std::string>>(), "search directory '$arg/providers' for providers.")
       ("log-level,l", po::value<log_level>()->default_value(log_level::warning, "warn"), "Set logging level.\nSupported levels are: none, trace, debug, info, warn, error, and fatal.")
+      ("json,j", "produce JSON output")
       ("version", "print the version and exit");
 
     po::options_description all_options(command_line_options);
@@ -193,7 +195,13 @@ int main(int argc, char **argv) {
 
     // Do the actual work
     auto ral = lib::ral::create(data_dirs);
-    auto em = lib::puppet_emitter();
+    std::unique_ptr<lib::emitter> emp;
+    if (vm.count("json")) {
+      emp = std::unique_ptr<lib::emitter>(new lib::json_emitter());
+    } else {
+      emp = std::unique_ptr<lib::emitter>(new lib::puppet_emitter());
+    }
+    lib::emitter& em = *emp;
 
     if (vm.count("type")) {
       // We have a type name

--- a/exe/ralsh.cc
+++ b/exe/ralsh.cc
@@ -180,6 +180,10 @@ int main(int argc, char **argv) {
 
     bool explain = vm.count("explain");
 
+    if (explain && vm.count("json")) {
+      boost::nowide::cerr << "error: " << "you can not specify --json and --explain at the same time" << endl;
+      boost::nowide::cerr << "error: " << "running 'ralsh --json' will contain explanations for all providers" << endl;
+    }
     // Figure out our include path
     std::vector<std::string> data_dirs;
     std::string env_data_dir;

--- a/exe/ralsh.cc
+++ b/exe/ralsh.cc
@@ -72,10 +72,10 @@ static void print_attr_explanation(const std::string& name,
        << name << color::reset
        << " : " << attr.desc() << endl;
   cout << "  " << left << setw(maxlen) << " "
-       << " . kind = " << color::blue << attr.get_kind()
+       << " . kind = " << color::blue << attr.kind()
                        << color::reset << endl;
   cout << "  " << left << setw(maxlen) << " "
-       << " . type = " << color::blue << attr.get_data_type()
+       << " . type = " << color::blue << attr.data_type()
                        << color::reset << endl;
 }
 

--- a/exe/ralsh.cc
+++ b/exe/ralsh.cc
@@ -279,9 +279,7 @@ int main(int argc, char **argv) {
       }
       // No type given, list known types
       auto types = ral->types();
-      for (const auto& t : types) {
-        boost::nowide::cout << t->qname() << endl;
-      }
+      em.print_types(types);
     }
   } catch (domain_error& ex) {
     colorize(boost::nowide::cerr, log_level::fatal);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -35,7 +35,8 @@ set(PROJECT_SOURCES "src/libral.cc" "src/augeas/handle.cc" "src/augeas/node.cc"
   "src/user.cc" "src/value.cc" "src/file.cc"
   "src/prov/spec.cc" "src/attr/spec.cc"
   "src/command.cc" "src/resource.cc" "src/context.cc"
-  "src/environment.cc")
+  "src/environment.cc"
+  "src/emitter/puppet_emitter.cc")
 
 ## An object target is generated that can be used by both the library and test executable targets.
 ## Without the intermediate target, unexported symbols can't be tested.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -36,7 +36,8 @@ set(PROJECT_SOURCES "src/libral.cc" "src/augeas/handle.cc" "src/augeas/node.cc"
   "src/prov/spec.cc" "src/attr/spec.cc"
   "src/command.cc" "src/resource.cc" "src/context.cc"
   "src/environment.cc"
-  "src/emitter/puppet_emitter.cc")
+  "src/emitter/puppet_emitter.cc"
+  "src/emitter/json_emitter.cc")
 
 ## An object target is generated that can be used by both the library and test executable targets.
 ## Without the intermediate target, unexported symbols can't be tested.

--- a/lib/inc/libral/attr/spec.hpp
+++ b/lib/inc/libral/attr/spec.hpp
@@ -82,8 +82,8 @@ namespace libral { namespace attr {
 
     const std::string& name() const { return _name; }
     const std::string& desc() const { return _desc; }
-    const data_type& get_data_type() const { return _data_type; }
-    const kind& get_kind() const { return _kind; }
+    const attr::data_type& data_type() const { return _data_type; }
+    const attr::kind& kind() const { return _kind; }
 
     /**
      * Create a spec from a textual description
@@ -106,14 +106,14 @@ namespace libral { namespace attr {
      */
     spec(const std::string& name,
          const std::string& desc,
-         data_type& data_type,
-         kind& kind)
+         attr::data_type& data_type,
+         attr::kind& kind)
       : _name(name), _desc(desc), _data_type(data_type), _kind(kind) { };
 
-    std::string _name;
-    std::string _desc;
-    data_type   _data_type;
-    kind        _kind;
+    std::string     _name;
+    std::string     _desc;
+    attr::data_type _data_type;
+    attr::kind      _kind;
   };
 
 } }  // namespace libral::attr

--- a/lib/inc/libral/emitter/emitter.hpp
+++ b/lib/inc/libral/emitter/emitter.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <libral/type.hpp>
+#include <libral/provider.hpp>
+
+namespace libral {
+  class emitter {
+  public:
+    virtual void print_set(const type &type,
+                 const result<std::pair<update, changes>>& rslt) = 0;
+
+    virtual void print_find(const type &type,
+                 const result<boost::optional<resource>> &resource) = 0;
+
+    virtual void print_list(const type &type,
+                 const result<std::vector<resource>>& resources) = 0;
+  };
+}

--- a/lib/inc/libral/emitter/emitter.hpp
+++ b/lib/inc/libral/emitter/emitter.hpp
@@ -14,5 +14,7 @@ namespace libral {
 
     virtual void print_list(const type &type,
                  const result<std::vector<resource>>& resources) = 0;
+
+    virtual void print_types(const std::vector<std::unique_ptr<type>>& types) = 0;
   };
 }

--- a/lib/inc/libral/emitter/json_emitter.hpp
+++ b/lib/inc/libral/emitter/json_emitter.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <libral/emitter/emitter.hpp>
+
+#include <leatherman/json_container/json_container.hpp>
+
+namespace libral {
+  class json_emitter : public emitter {
+  public:
+
+    using json = leatherman::json_container::JsonContainer;
+
+    void print_set(const type &type,
+               const result<std::pair<update, changes>>& rslt) override;
+
+    void print_find(const type &type,
+               const result<boost::optional<resource>> &resource) override;
+
+    void print_list(const type &type,
+               const result<std::vector<resource>>& resources) override;
+  private:
+    json resource_to_json(const type& type, const resource &res);
+    json json_meta(const type &type);
+    /* Set KEY in JS by appropriately converting V */
+    void json_set_value(json &js, const std::string& key, const value &v);
+  };
+}

--- a/lib/inc/libral/emitter/json_emitter.hpp
+++ b/lib/inc/libral/emitter/json_emitter.hpp
@@ -18,6 +18,9 @@ namespace libral {
 
     void print_list(const type &type,
                const result<std::vector<resource>>& resources) override;
+
+    void print_types(const std::vector<std::unique_ptr<type>>& types) override;
+
   private:
     json resource_to_json(const type& type, const resource &res);
     json json_meta(const type &type);

--- a/lib/inc/libral/emitter/puppet_emitter.hpp
+++ b/lib/inc/libral/emitter/puppet_emitter.hpp
@@ -14,6 +14,9 @@ namespace libral {
 
     void print_list(const type &type,
                const result<std::vector<resource>>& resources) override;
+
+    void print_types(const std::vector<std::unique_ptr<type>>& types) override;
+
   private:
     void print_resource(const type &type, const resource &resource);
     void print_resource_attr(const std::string& name,

--- a/lib/inc/libral/emitter/puppet_emitter.hpp
+++ b/lib/inc/libral/emitter/puppet_emitter.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <libral/emitter/emitter.hpp>
+
+namespace libral {
+  class puppet_emitter : public emitter {
+  public:
+    puppet_emitter();
+    void print_set(const type &type,
+               const result<std::pair<update, changes>>& rslt) override;
+
+    void print_find(const type &type,
+               const result<boost::optional<resource>> &resource) override;
+
+    void print_list(const type &type,
+               const result<std::vector<resource>>& resources) override;
+  private:
+    void print_resource(const type &type, const resource &resource);
+    void print_resource_attr(const std::string& name,
+                             const value& v,
+                             uint maxlen);
+  };
+}

--- a/lib/inc/libral/result.hpp
+++ b/lib/inc/libral/result.hpp
@@ -166,11 +166,25 @@ namespace libral {
     R& operator*() { return ok(); }
 
     /**
+     * Returns the const ok value.
+     *
+     * @throws std::logic_error if the result is an error and not ok
+     */
+    const R& operator*() const { return ok(); }
+
+    /**
      * Returns a pointer to the ok value.
      *
      * @throws std::logic_error if the result is an error and not ok
      */
     R* operator->() { return &ok(); }
+
+    /**
+     * Returns a const pointer to the ok value.
+     *
+     * @throws std::logic_error if the result is an error and not ok
+     */
+    const R* operator->() const { return &ok(); }
 
     static std::unique_ptr<result<R>> make_unique() {
       return std::unique_ptr<result<R>>(new result<R>(R()));

--- a/lib/inc/libral/type.hpp
+++ b/lib/inc/libral/type.hpp
@@ -29,6 +29,7 @@ namespace libral {
     result<value> parse(const std::string &name, const std::string &v);
 
     provider& prov() { return *_prov; };
+    const provider& prov() const { return *_prov; };
   private:
     std::string _name;
     std::shared_ptr<provider> _prov;

--- a/lib/src/attr/spec.cc
+++ b/lib/src/attr/spec.cc
@@ -130,7 +130,7 @@ namespace libral { namespace attr {
     std::string ts = type_str;
     boost::trim(ts);
 
-    data_type dt;
+    attr::data_type dt;
     if (ts == "boolean") {
       dt = boolean_type();
     } else if (ts == "string") {

--- a/lib/src/emitter/json_emitter.cc
+++ b/lib/src/emitter/json_emitter.cc
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 
 using namespace leatherman::logging;
 using namespace leatherman::locale;
@@ -67,6 +68,44 @@ namespace libral {
       }
       js.set<std::vector<json>>("resources", list);
     }
+    std::cout << js.toString() << std::endl;
+  }
+
+  void json_emitter::print_types(const std::vector<std::unique_ptr<type>>& types) {
+    json js;
+    std::vector<json> list;
+    for (const auto& t : types) {
+      json entry;
+      entry.set<std::string>("name", t->qname());
+      entry.set<std::string>("type", t->type_name());
+      entry.set<std::string>("source", t->prov().source());
+
+      const auto& spec = t->prov().spec();
+      if (spec) {
+        entry.set<std::string>("desc", spec->desc());
+        entry.set<bool>("suitable", spec->suitable());
+        std::vector<json> attributes;
+        for (auto it = spec->attr_begin(); it != spec->attr_end(); it++) {
+          const auto &a = it->second;
+          json attr;
+
+          attr.set<std::string>("name", a.name());
+          attr.set<std::string>("desc", a.desc());
+
+          std::ostringstream os;
+          os << a.get_data_type();
+          attr.set<std::string>("type", os.str());
+          os.str("");
+          os << a.get_kind();
+          attr.set<std::string>("kind", os.str());
+          attributes.push_back(attr);
+        }
+        entry.set<std::vector<json>>("attributes", attributes);
+      }
+
+      list.push_back(entry);
+    }
+    js.set<std::vector<json>>("providers", list);
     std::cout << js.toString() << std::endl;
   }
 

--- a/lib/src/emitter/json_emitter.cc
+++ b/lib/src/emitter/json_emitter.cc
@@ -93,10 +93,10 @@ namespace libral {
           attr.set<std::string>("desc", a.desc());
 
           std::ostringstream os;
-          os << a.get_data_type();
+          os << a.data_type();
           attr.set<std::string>("type", os.str());
           os.str("");
-          os << a.get_kind();
+          os << a.kind();
           attr.set<std::string>("kind", os.str());
           attributes.push_back(attr);
         }

--- a/lib/src/emitter/json_emitter.cc
+++ b/lib/src/emitter/json_emitter.cc
@@ -1,0 +1,123 @@
+#include <libral/emitter/json_emitter.hpp>
+
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/json_container/json_container.hpp>
+
+#include <iostream>
+#include <iomanip>
+
+using namespace leatherman::logging;
+using namespace leatherman::locale;
+
+namespace libral {
+
+  using json = leatherman::json_container::JsonContainer;
+
+  void json_emitter::print_set(const type &type,
+                       const result<std::pair<update, changes>>& rslt) {
+    json js;
+
+    if (!rslt) {
+      json err;
+      err.set<std::string>("message", _("failed: {1}", rslt.err().detail));
+      js.set<json>("error", err);
+    } else {
+      const auto rsrc = type.prov().create(rslt->first, rslt->second);
+      js.set<json>("resource", resource_to_json(type, rsrc));
+      const auto &changes = rslt->second;
+      std::vector<json> json_changes;
+      for (auto ch : changes) {
+        json json_ch;
+        json_ch.set<std::string>("attr", ch.attr);
+        json_set_value(json_ch, "is", ch.is);
+        json_set_value(json_ch, "was", ch.was);
+        json_changes.push_back(json_ch);
+      }
+      js.set<std::vector<json>>("changes", json_changes);
+    }
+    std::cout << js.toString() << std::endl;
+  }
+
+  void json_emitter::print_find(const type &type,
+                       const result<boost::optional<resource>> &inst) {
+    json js;
+
+    if (!inst) {
+      json err;
+      err.set<std::string>("message", _("failed: {1}", inst.err().detail));
+      js.set<json>("error", err);
+    } else if (inst.ok()) {
+      js.set<json>("resource", resource_to_json(type, *inst.ok()));
+    }
+    std::cout << js.toString() << std::endl;
+  }
+
+  void json_emitter::print_list(const type &type,
+                       const result<std::vector<resource>>& rslt) {
+    json js;
+
+    if (!rslt) {
+      json err;
+      err.set<std::string>("message", _("failed: {1}", rslt.err().detail));
+      js.set<json>("error", err);
+    } else {
+      std::vector<json> list;
+      for (const auto& inst : rslt.ok()) {
+        list.push_back(resource_to_json(type, inst));
+      }
+      js.set<std::vector<json>>("resources", list);
+    }
+    std::cout << js.toString() << std::endl;
+  }
+
+  json json_emitter::resource_to_json(const type &type, const resource &res) {
+    json js;
+
+    js.set<std::string>("name", res.name());
+    for (const auto& a : res.attrs()) {
+      json_set_value(js, a.first, a.second);
+    }
+    js.set<json>("ral", json_meta(type));
+    return js;
+  }
+
+  json json_emitter::json_meta(const type &type) {
+      json meta;
+      meta.set<std::string>("type", type.type_name());
+      meta.set<std::string>("provider", type.qname());
+      return meta;
+  }
+
+  /* Set a json attribute from a value */
+  struct value_to_json_visitor : boost::static_visitor<> {
+    value_to_json_visitor(json &js, const std::string &key)
+      : _js(js), _key(key) { };
+
+    void operator()(const boost::none_t& n) const {
+      // FIXME: we really want JSON null here
+      _js.set<std::string>(_key, "__none__");
+    }
+
+    void operator()(const bool& b) const {
+      _js.set<bool>(_key, b);
+    }
+
+    void operator()(const std::string& s) const {
+      _js.set<std::string>(_key, s);
+    }
+
+    void operator()(const array& ary) const {
+      _js.set<std::vector<std::string>>(_key, ary);
+    }
+
+  private:
+    json& _js;
+    const std::string& _key;
+  };
+
+  void json_emitter::json_set_value(json &js, const std::string& key,
+                                    const value &v) {
+    boost::apply_visitor(value_to_json_visitor(js, key), v);
+  }
+
+}

--- a/lib/src/emitter/puppet_emitter.cc
+++ b/lib/src/emitter/puppet_emitter.cc
@@ -70,6 +70,12 @@ namespace libral {
     }
   }
 
+  void puppet_emitter::print_types(const std::vector<std::unique_ptr<type>>& types) {
+    for (const auto& t : types) {
+      std::cout << t->qname() << std::endl;
+    }
+  }
+
   void puppet_emitter::print_resource(const type &type, const resource &res) {
     std::cout << color::blue << type.qname() << color::reset << " { '"
          << color::blue << res.name() << color::reset << "':" << std::endl;

--- a/lib/src/emitter/puppet_emitter.cc
+++ b/lib/src/emitter/puppet_emitter.cc
@@ -1,0 +1,99 @@
+#include <libral/emitter/puppet_emitter.hpp>
+
+#include <leatherman/logging/logging.hpp>
+
+#include <iostream>
+#include <iomanip>
+
+using namespace leatherman::logging;
+using namespace leatherman::locale;
+
+namespace libral {
+
+  namespace color {
+  // Very poor man's output coloring. Call init() to fill these
+  // with color escape sequences
+  std::string cyan, green, yellow, red, magenta, blue, reset;
+
+  void init() {
+    if (isatty(1)) {
+      cyan = "\33[0;36m";
+      green = "\33[0;32m";
+      yellow = "\33[0;33m";
+      red = "\33[0;31m";
+      magenta = "\33[0;35m";
+      blue = "\33[0;34m";
+
+      reset = "\33[0m";
+    }
+  } } // namespace color
+
+
+  puppet_emitter::puppet_emitter() {
+    // Color handling is horrible: as a side-effect of crating a puppet_emitter,
+    // we initialize the global color constants.
+    color::init();
+  }
+
+  void puppet_emitter::print_set(const type &type,
+                       const result<std::pair<update, changes>>& rslt) {
+    if (rslt) {
+      const auto& upd = rslt->first;
+      const auto &chgs = rslt->second;
+      print_resource(type, type.prov().create(upd, chgs));
+      std::cout << chgs << std::endl;
+    } else {
+      std::cout << color::red << _("failed: {1}", rslt.err().detail) << color::reset << std::endl;
+    }
+  }
+
+  void puppet_emitter::print_find(const type &type,
+                       const result<boost::optional<resource>> &inst) {
+    if (!inst) {
+      std::cerr << color::red <<
+        _("failed: {1}", inst.err().detail) << color::reset << std::endl;
+      return;
+    }
+    if (inst.ok()) {
+      print_resource(type, *inst.ok());
+    }
+  }
+
+  void puppet_emitter::print_list(const type &type,
+                       const result<std::vector<resource>>& rslt) {
+    if (!rslt) {
+      std::cout << color::red << _("failed: {1}", rslt.err().detail) << color::reset << std::endl;
+      return;
+    }
+    for (const auto& inst : rslt.ok()) {
+      print_resource(type, inst);
+    }
+  }
+
+  void puppet_emitter::print_resource(const type &type, const resource &res) {
+    std::cout << color::blue << type.qname() << color::reset << " { '"
+         << color::blue << res.name() << color::reset << "':" << std::endl;
+    uint maxlen = 0;
+    for (const auto& a : res.attrs()) {
+      if (a.first.length() > maxlen) maxlen = a.first.length();
+    }
+    auto ens = res.lookup<std::string>("ensure");
+    if (ens) {
+      print_resource_attr("ensure", *ens, maxlen);
+    }
+    for (const auto& a : res.attrs()) {
+      if (a.first == "ensure")
+        continue;
+      print_resource_attr(a.first, a.second, maxlen);
+    }
+    std::cout << "}" << std::endl;
+  }
+
+  void puppet_emitter::print_resource_attr(const std::string& name,
+                                           const value& v,
+                                           uint maxlen) {
+    std::cout << "  " << color::green << std::left << std::setw(maxlen)
+              << name << color::reset
+              << " => '" << v << "'," << std::endl;
+  }
+}

--- a/lib/tests/attr/spec.cc
+++ b/lib/tests/attr/spec.cc
@@ -8,8 +8,8 @@ namespace libral { namespace attr {
       REQUIRE(spec);
       REQUIRE(spec->name() == "test");
       REQUIRE(spec->desc() == "Test desc");
-      REQUIRE(spec->get_data_type().type() == typeid(string_type));
-      REQUIRE(spec->get_kind().get_tag() == kind::tag::r);
+      REQUIRE(spec->data_type().type() == typeid(string_type));
+      REQUIRE(spec->kind().get_tag() == kind::tag::r);
     }
 
     SECTION("creates boolean type") {
@@ -17,8 +17,8 @@ namespace libral { namespace attr {
       REQUIRE(spec);
       REQUIRE(spec->name() == "test");
       REQUIRE(spec->desc() == "Test desc");
-      REQUIRE(spec->get_data_type().type() == typeid(boolean_type));
-      REQUIRE(spec->get_kind().get_tag() == kind::tag::w);
+      REQUIRE(spec->data_type().type() == typeid(boolean_type));
+      REQUIRE(spec->kind().get_tag() == kind::tag::w);
     }
 
     SECTION("creates a array[string] type") {
@@ -31,8 +31,8 @@ namespace libral { namespace attr {
           REQUIRE(spec);
           REQUIRE(spec->name() == "test");
           REQUIRE(spec->desc() == "Test desc");
-          REQUIRE(spec->get_data_type().type() == typeid(array_type));
-          REQUIRE(spec->get_kind().get_tag() == kind::tag::rw);
+          REQUIRE(spec->data_type().type() == typeid(array_type));
+          REQUIRE(spec->kind().get_tag() == kind::tag::rw);
         }
       }
     }
@@ -65,12 +65,12 @@ namespace libral { namespace attr {
           REQUIRE(spec);
           REQUIRE(spec->name() == "test");
           REQUIRE(spec->desc() == "Test desc");
-          auto& data_type = spec->get_data_type();
+          auto& data_type = spec->data_type();
           REQUIRE(data_type.type() == typeid(enum_type));
           auto& enum_t = boost::get<enum_type>(data_type);
           std::vector<std::string> opts = { "yes", "no" };
           REQUIRE(enum_t.options() == opts);
-          REQUIRE(spec->get_kind().get_tag() == kind::tag::r);
+          REQUIRE(spec->kind().get_tag() == kind::tag::r);
         }
       }
     }


### PR DESCRIPTION
With these changes, `ralsh` accepts a `--json` flag which makes it format its output as JSON.

This is functional, but before this can be committed, I need to add documentation of that output.