### PR TITLE
(MAINT) Bump leatherman version to 1.0.0

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -26,7 +26,7 @@ time, not at runtime.
 ```bash
     git clone https://github.com/puppetlabs/leatherman.git
     cd leatherman
-    git checkout 0.10.1
+    git checkout 1.0.0
     mkdir build && cd build
     cmake ..
     make
@@ -92,7 +92,7 @@ comes with `puppet-agent` by appending `/opt/puppetlabs/puppet/bin` to your
            -DCMAKE_INSTALL_PREFIX=/opt/puppetlabs/puppet'
     git clone https://github.com/puppetlabs/leatherman.git
     cd leatherman
-    git checkout 0.10.1
+    git checkout 1.0.0
     mkdir build && cd build
     pl-cmake -DBOOST_STATIC=ON ..
     make
@@ -153,7 +153,7 @@ Follow the same instructions as building on Linux.
 ```bash
     git clone https://github.com/puppetlabs/leatherman.git
     cd leatherman
-    git checkout 0.10.1
+    git checkout 1.0.0
     mkdir build && cd build
     cmake ..
     make

--- a/contrib/docker/scripts/image.sh
+++ b/contrib/docker/scripts/image.sh
@@ -69,7 +69,7 @@ EOF
 git clone https://github.com/puppetlabs/leatherman
 mkdir -p leatherman/build
 cd leatherman/build
-git checkout -q 0.10.1
+git checkout -q 1.0.0
 $CMAKE -DBOOST_STATIC=$STATIC ..
 make all install
 make clean


### PR DESCRIPTION
This PR bumps the `leatherman` version to `1.0.0` to bring it in line with the version used for facter, mainly to facilitate statically compiling a binary that is using both libral and facter.