### PR TITLE
(MAINT) Pin mruby-iijson to working version (workaround for #44)

### DIFF
--- a/mruby/libral.gembox
+++ b/mruby/libral.gembox
@@ -84,7 +84,7 @@ MRuby::GemBox.new do |conf|
   conf.gem :github => 'iij/mruby-io'
 
   # JSON parser and generator
-  conf.gem :github => 'iij/mruby-iijson'
+  conf.gem :github => 'iij/mruby-iijson', :checksum_hash => '2472d063fce158249862b43bf51a84aec63336c7'
 
   # Bindings to augeas
   conf.gem :github => "hercules-team/mruby-augeas" do |g|


### PR DESCRIPTION
This commit pins mruby-iijson to the version before the recent upstream change to json.c
(iij/mruby-iijson@6146eecb059d696e11390e864e2adb04326dcf06).

Adding a a temporary workaround to #44