### PR TITLE
(DI-362) Add SetResource to libralgo binding

### DIFF
--- a/lib/inc/libral/cwrapper.hpp
+++ b/lib/inc/libral/cwrapper.hpp
@@ -7,7 +7,8 @@ extern "C" {
 #endif
 
 uint8_t get_providers(char **result);
-uint8_t get_resource(char **result, char *type_name,  char *resource_name);
+uint8_t get_resource(char **result, char *type_name, char *resource_name);
+uint8_t set_resource(char **result, char *type_name, char *resource_name, int desired_attributes_c, char **desired_attributes);
 uint8_t get_resources(char **result, char *type_name);
 
 #ifdef __cplusplus

--- a/libralgo/types/types.go
+++ b/libralgo/types/types.go
@@ -32,12 +32,21 @@ type Provider struct {
 //
 //  - RAL provider which exposed the resource
 //  - Attributes map of attributes exposed by the provider
-//  - Raw JSON representation of the resource as a []byte
+//  - Changes list of changes in response to a set, omitted if empty
 type Resource struct {
 	Name       string                 `json:"name"`
 	RAL        RAL                    `json:"ral"`
 	Attributes map[string]interface{} `json:"attributes"`
-	Raw        []byte                 `json:"raw"`
+	Changes    []Change               `json:"changes,omitempty"`
+}
+
+// Change describes how an attributed has changed after invoking
+// SetResource, showing the attributes value both before (`was`),
+// and after (`is`) the set has completed successfully.
+type Change struct {
+	Attribute string `json:"attr"`
+	Is        string `json:"is"`
+	Was       string `json:"was"`
 }
 
 // ProvidersResult represents a result from a get_providers call
@@ -53,4 +62,5 @@ type ResourcesResult struct {
 // ResourceResult represents a result from a get_resource call
 type ResourceResult struct {
 	Resource json.RawMessage `json:"resource"`
+	Changes  json.RawMessage `json:"changes,omitempty"`
 }


### PR DESCRIPTION
This PR adds the `SetResource` function to the libralgo binding, allows the setting of attributes on resources (either change or creating them in the process).

For example:
```go
attributes := map[string]string{"ensure": "present"}
resource, changes, err := libral.SetResource("package", "httpd", attributes)
```
Results in the following updated `resource`:
```json
{
  "name": "httpd",
  "ral": {
    "type": "package",
    "provider": "package::yum"
  },
  "attributes": {
    "ensure": "0:2.2.15-60.el6.centos.5",
    "name": "httpd"
  }
}
```
And an associated slice of `changes`:
```json
{
    "changes": [
        {
            "attr": "ensure",
            "is": "0:2.2.15-60.el6.centos.5",
            "was": "absent"
        }
    ]
}
```