### PR TITLE
Change travis setup so that we use the git checkout from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 script:
   - docker pull $TARGET
-  - docker run -e 'MAKEFLAGS=-j2' $TARGET
+  - docker run -e 'MAKEFLAGS=-j2' -v "$TRAVIS_BUILD_DIR:/usr/src/libral" $TARGET /bin/bash /usr/src/libral/contrib/docker/scripts/build.sh
 
 env:
   matrix:

--- a/contrib/docker/scripts/build.sh
+++ b/contrib/docker/scripts/build.sh
@@ -3,11 +3,9 @@
 # Do the actual libral build. This assumes that all necessary tools,
 # including leatherman, have been set up already
 
-topdir=$(readlink --canonicalize $(dirname $0)/..)
-
 set -ex
 
-cd $topdir
+cd /usr/src
 
 source build_config.sh
 
@@ -20,14 +18,21 @@ if [ ! -d libral ]; then
     echo "Cloning libral"
     git clone https://github.com/puppetlabs/libral
 else
+    # When we build in containers in Travis, we use the checkout that
+    # Travis made on the host, and do not check anything out ourselves
     echo "Building from existing libral directory"
 fi
 
-rm -rf libral/build
-mkdir libral/build
-cd libral/build
+cd libral
+echo "Building commit $(git rev-parse HEAD)"
+src_dir=$(pwd)
 
-$CMAKE -DLIBRAL_STATIC=$STATIC ..
+cd /var/tmp
+rm -rf build
+mkdir build
+
+cd build
+$CMAKE -DLIBRAL_STATIC=$STATIC $src_dir
 
 make all test install
 
@@ -35,5 +40,5 @@ make all test install
 
 if [ "$STATIC" = "ON" ]
 then
-    $topdir/scripts/check-static-libs.rb
+    /usr/src/libral/contrib/docker/scripts/check-static-libs.rb
 fi

--- a/contrib/docker/scripts/check-static-libs.rb
+++ b/contrib/docker/scripts/check-static-libs.rb
@@ -1,4 +1,4 @@
-#! /usr/src/libral/build/bin/mruby
+#! /var/tmp/build/bin/mruby
 
 # Check for a static build that we only link to DSO's that we are ok with;
 # those are the libraries that will be present on any glibc-based system
@@ -8,7 +8,7 @@ ALLOWED=%w(linux-vdso.so.1 librt.so.1 libm.so.6 libpthread.so.0
            libc.so.6 libdl.so.2 /lib64/ld-linux-x86-64.so.2)
 
 # Where to find the binaries to check
-BINDIR="/usr/src/libral/build/bin"
+BINDIR="/var/tmp/build/bin"
 BINARIES=%w(ralsh mirb mruby)
 
 


### PR DESCRIPTION
We used to do our own git checkout of the code, which was wrong, as we
would always run against master, even when we were testing a PR or other
branch.

We now map Travis' git checkout into our container. We also use the
build.sh file from the checkout so that changing that doesn't require
rebuilding the containers.

Fixes: https://github.com/puppetlabs/libral/issues/51