### PR TITLE
Set AUGEAS_LENS_LIB to load lenses from our data dir

### DIFF
--- a/lib/inc/libral/augeas/handle.hpp
+++ b/lib/inc/libral/augeas/handle.hpp
@@ -70,14 +70,13 @@ namespace libral { namespace augeas {
      * the node at PATH if it doesn't exist yet.*/
     node make_node_seq_next(const std::string& path);
 
-    static std::shared_ptr<handle> make(const std::string& loadpath,
-                                        unsigned int flags) {
-      return std::shared_ptr<handle>(new handle(loadpath, flags));
+    static std::shared_ptr<handle> make(unsigned int flags) {
+      return std::shared_ptr<handle>(new handle(flags));
     }
 
   private:
-    handle(const std::string& loadpath, unsigned int flags)
-      : _augeas(aug_init(NULL, loadpath.c_str(), flags)) { };
+    handle(unsigned int flags)
+      : _augeas(aug_init(NULL, NULL, flags)) { };
 
     /* Checks _augeas for errors and return an error if there is one. */
     result<void> check_error() const;

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -16,18 +16,7 @@ namespace libral {
 
   result<std::shared_ptr<augeas::handle>>
   environment::augeas(const std::vector<std::pair<std::string, std::string>>& xfms) {
-
-    std::stringstream buf;
-    bool first=true;
-
-    for (auto dir : data_dirs()) {
-      if (!first)
-        buf << ":";
-      first=false;
-      buf << dir << "/lenses";
-    }
-
-    auto aug = aug::handle::make(buf.str(), AUG_NO_MODL_AUTOLOAD);
+    auto aug = aug::handle::make(AUG_NO_MODL_AUTOLOAD);
     for (auto& xfm : xfms) {
       err_ret( aug->include(xfm.first, xfm.second) );
     }

--- a/mruby/libral.gembox
+++ b/mruby/libral.gembox
@@ -86,6 +86,9 @@ MRuby::GemBox.new do |conf|
   # JSON parser and generator
   conf.gem :github => 'iij/mruby-iijson'
 
+  # ENV access
+  conf.gem :github => 'iij/mruby-env'
+
   # Bindings to augeas
   conf.gem :github => "hercules-team/mruby-augeas" do |g|
     libral_configure_mruby_augeas(g)


### PR DESCRIPTION
We used to just pass the right path for lenses to aug_init, but that does
not change where external providers load lenses from, such as
ssh_authorized_key.

We now add our lens directories to the environment variable
AUGEAS_LENS_LIB; that changes it both for uses of augeas for internal and
external providers.

Fixes https://github.com/puppetlabs/libral/issues/54