### PR TITLE
(DI-834) Fix system provider on old systemd versions

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -198,7 +198,7 @@ You can build the example client (`examples/go/listproviders.go`) as follows:
     cd libral/contrib/docker
     make el6-build-static-go
     cd ../../
-    docker run --rm -it -v ${PWD}:/usr/src/libral libral-build-go
+    docker run --rm -it -v ${PWD}:/usr/src/libral libral/el6-build-static-go
 ```
 
 This will place the built binary and a packaged archive (based on `statpack`) in the

--- a/data/providers/systemd.prov
+++ b/data/providers/systemd.prov
@@ -71,7 +71,7 @@ find_state() {
     [ -z "$name" ] && die "find: missing a name"
 
     # See if we even have a unit file
-    out=$(systemctl list-unit-files -t service --no-pager --no-legend "${name}.service")
+    out=$(systemctl list-unit-files -t service --no-pager --no-legend | egrep "${name}.service")
 
     if [ -n "$out" ]
     then


### PR DESCRIPTION
The `find_state` function was relying on the ability to pass the unit file to `systemctl list-unit-files` command, the ability to do so was added at some point after systemd `208`. RHEL shipped with version `208`, so attempting to get the status of a service on an un-upgraded system would subsequently fail.

This commit switches to using `systemctl` with `grep` in the `find_state` function to determine the state of a service.
