### PR TITLE
(DI-858) Go binding SetResource updated result structure

### DIFF
--- a/libralgo/types/types.go
+++ b/libralgo/types/types.go
@@ -59,6 +59,11 @@ type ResourcesResult struct {
 	Resources []json.RawMessage `json:"resources"`
 }
 
+// SetResourceResult represents a result from a set_resource call
+type SetResourceResult struct {
+	Result []json.RawMessage `json:"result"`
+}
+
 // ResourceResult represents a result from a get_resource call
 type ResourceResult struct {
 	Resource json.RawMessage `json:"resource"`


### PR DESCRIPTION
This commit updates the SetResource function in the go binding following an update to the underlying data structure returned from the C++ library.

The set resource result is now returned in a result map as an array of resources (see [here](https://github.com/puppetlabs/libral/compare/DI-858/master/update-go-binding-for-set-resource?expand=1#diff-a22b6d3c30f864e30aeef8130092ebc1L273)).