### PR TITLE
Add the ability to manage remote systems via ssh

### DIFF
--- a/data/providers/apt.prov
+++ b/data/providers/apt.prov
@@ -9,36 +9,6 @@ die() {
 }
 
 # A provider for managing packages with apt tools
-is_suitable() {
-    type -p dpkg apt-get apt-cache > /dev/null && return 0 || return 1
-}
-
-describe() {
-    local suitable
-    is_suitable && suitable=true || suitable=false
-    cat <<EOF
----
-provider:
-  type: package
-  invoke: simple
-  actions: [list, find]
-  suitable: ${suitable}
-  attributes:
-    name:
-      desc: the name of the package
-    ensure:
-      desc: what state the package should be in
-      # Our type system is not strong enough to be more precise. ensure is
-      # either one of enum[present,installed,absent,purged,held,latest] or
-      # a version number (so string might be as tightly as this can be
-      # typed anyway
-      type: string
-    platform:
-      desc: the platform (architecture) for which the package was built
-      kind: r
-EOF
-}
-
 list() {
     echo '# simple'
     dpkg -l | awk '$1 ~ /ii/ { printf "name: %s\nensure: %s\nplatform: %s\n",$2,$3,$4}'
@@ -91,7 +61,6 @@ in
     list) list;;
     find) find;;
     update) update;;
-    describe) describe;;
     *)
         die "Unknown action: $ral_action"
 esac

--- a/data/providers/apt.yaml
+++ b/data/providers/apt.yaml
@@ -1,0 +1,20 @@
+---
+provider:
+  type: package
+  invoke: simple
+  actions: [list, find]
+  suitable:
+    commands: [dpkg, apt-get, apt-cache]
+  attributes:
+    name:
+      desc: the name of the package
+    ensure:
+      desc: what state the package should be in
+      # Our type system is not strong enough to be more precise. ensure is
+      # either one of enum[present,installed,absent,purged,held,latest] or
+      # a version number (so string might be as tightly as this can be
+      # typed anyway
+      type: string
+    platform:
+      desc: the platform (architecture) for which the package was built
+      kind: r

--- a/data/providers/dnf.yaml
+++ b/data/providers/dnf.yaml
@@ -1,0 +1,20 @@
+---
+provider:
+  type: package
+  invoke: json
+  actions: [set, get]
+  suitable:
+    commands: [dnf]
+  attributes:
+    name:
+      desc: the name of the package
+    ensure:
+      desc: what state the package should be in
+      # Our type system is not strong enough to be more precise. ensure is
+      # either one of enum[present,installed,absent,purged,held,latest] or
+      # a version number (so string might be as tightly as this can be
+      # typed anyway
+      type: string
+    platform:
+      desc: the platform (architecture) for which the package was built
+      kind: r

--- a/data/providers/dnf_provider.py
+++ b/data/providers/dnf_provider.py
@@ -14,7 +14,8 @@ provider:
   type: package
   invoke: json
   actions: [set, get]
-  suitable: {suitable}
+  suitable:
+    commands: [dnf]
   attributes:
     name:
       desc: the name of the package

--- a/data/providers/ssh_authorized_key.prov
+++ b/data/providers/ssh_authorized_key.prov
@@ -11,44 +11,7 @@ class SshAuthorizedKey
 
   # INTERFACE METHOD: return YAML metadata
   def describe(ctx)
-    puts <<EOS
----
-provider:
-  type: ssh_authorized_key
-  desc: |
-    Manage ssh authorized keys in user's .ssh/authorized_keys files
-  invoke: json
-  actions: [set, get]
-  suitable: true
-  attributes:
-    name:
-      desc: |
-        The SSH key comment. This can be anything, and doesn't need to match
-        the original comment from the `.pub` file.
-
-        Due to internal limitations, this must be unique across all user
-        accounts; if you want to specify one key for multiple users, you
-        must use a different comment for each instance.
-    ensure:
-      type: enum[absent, present]
-    key:
-      desc: |
-        The public key itself. Generally, a long string of hex characters.
-        The `key` attribute may not contain whitespace.
-    type:
-      desc: The encryption type used.
-    user:
-      desc: |
-        The user account in which the SSH key should be installed.
-    options:
-      type: array[string]
-      desc: |
-        Key options; see sshd(8) for possible values.
-    target:
-      type: string
-      desc: The absolute path to the file containing the key
-      kind: r
-EOS
+    raise "Wat ?"
   end
 
   def get(ctx, names)

--- a/data/providers/ssh_authorized_key.yaml
+++ b/data/providers/ssh_authorized_key.yaml
@@ -5,7 +5,8 @@ provider:
     Manage ssh authorized keys in user's .ssh/authorized_keys files
   invoke: json
   actions: [set, get]
-  suitable: true
+  suitable:
+    commands: [mruby]
   attributes:
     name:
       desc: |

--- a/data/providers/ssh_authorized_key.yaml
+++ b/data/providers/ssh_authorized_key.yaml
@@ -1,0 +1,36 @@
+---
+provider:
+  type: ssh_authorized_key
+  desc: |
+    Manage ssh authorized keys in user's .ssh/authorized_keys files
+  invoke: json
+  actions: [set, get]
+  suitable: true
+  attributes:
+    name:
+      desc: |
+        The SSH key comment. This can be anything, and doesn't need to match
+        the original comment from the `.pub` file.
+
+        Due to internal limitations, this must be unique across all user
+        accounts; if you want to specify one key for multiple users, you
+        must use a different comment for each instance.
+    ensure:
+      type: enum[absent, present]
+    key:
+      desc: |
+        The public key itself. Generally, a long string of hex characters.
+        The `key` attribute may not contain whitespace.
+    type:
+      desc: The encryption type used.
+    user:
+      desc: |
+        The user account in which the SSH key should be installed.
+    options:
+      type: array[string]
+      desc: |
+        Key options; see sshd(8) for possible values.
+    target:
+      type: string
+      desc: The absolute path to the file containing the key
+      kind: r

--- a/data/providers/systemd.prov
+++ b/data/providers/systemd.prov
@@ -16,26 +16,6 @@ die() {
     exit 0
 }
 
-describe() {
-    type -p systemctl > /dev/null && suitable=true || suitable=false
-
-    cat <<EOF
----
-provider:
-  type: service
-  invoke: simple
-  actions: [list,find,update]
-  suitable: ${suitable}
-  attributes:
-    name:
-      type: string
-    ensure:
-      type: enum[running, stopped]
-    enable:
-      type: enum[true, false, mask]
-EOF
-}
-
 list() {
     echo '# simple'
     # This looks super-hairy, but is actually quite simple:
@@ -176,7 +156,6 @@ in
     list) list;;
     find) find;;
     update) update;;
-    describe) describe;;
     *)
         die "Unknown action: $ral_action"
 esac

--- a/data/providers/systemd.yaml
+++ b/data/providers/systemd.yaml
@@ -1,0 +1,14 @@
+---
+provider:
+  type: service
+  invoke: simple
+  actions: [list,find,update]
+  suitable:
+    commands: [systemctl]
+  attributes:
+    name:
+      type: string
+    ensure:
+      type: enum[running, stopped]
+    enable:
+      type: enum[true, false, mask]

--- a/data/providers/yum.prov
+++ b/data/providers/yum.prov
@@ -7,33 +7,7 @@ import os
 import subprocess
 import traceback
 
-try:
-    import yum
-    HAS_YUM = True
-except ImportError:
-    HAS_YUM = False
-
-METADATA="""
----
-provider:
-  type: package
-  invoke: json
-  actions: [set, get]
-  suitable: {suitable}
-  attributes:
-    name:
-      desc: the name of the package
-    ensure:
-      desc: what state the package should be in
-      # Our type system is not strong enough to be more precise. ensure is
-      # either one of enum[present,installed,absent,purged,held,latest] or
-      # a version number (so string might be as tightly as this can be
-      # typed anyway
-      type: string
-    platform:
-      desc: the platform (architecture) for which the package was built
-      kind: r
-"""
+import yum
 
 #
 # Utility methods
@@ -108,11 +82,6 @@ def find_installed(base, name):
 #
 # Provider actions
 #
-def do_describe():
-    has_dnf=pkgutil.find_loader("dnf")
-    suitable=HAS_YUM and not has_dnf
-    print(METADATA.format(suitable=str(suitable).lower()))
-
 def do_get(inp):
     names=inp["names"]
     base=yum_base()
@@ -248,9 +217,7 @@ def main():
         print("usage: yum.prov ral_action=<action>")
         sys.exit(1)
     action=sys.argv[1].split("=")[-1]
-    if action == "describe":
-        do_describe()
-    elif action == "get":
+    if action == "get":
         dump(do_get(parse_stdin()))
     elif action == "set":
         dump(do_set(parse_stdin()))

--- a/data/providers/yum.yaml
+++ b/data/providers/yum.yaml
@@ -1,0 +1,20 @@
+---
+provider:
+  type: package
+  invoke: json
+  actions: [set, get]
+  suitable:
+    commands: [yum, not dnf]
+  attributes:
+    name:
+      desc: the name of the package
+    ensure:
+      desc: what state the package should be in
+      # Our type system is not strong enough to be more precise. ensure is
+      # either one of enum[present,installed,absent,purged,held,latest] or
+      # a version number (so string might be as tightly as this can be
+      # typed anyway
+      type: string
+    platform:
+      desc: the platform (architecture) for which the package was built
+      kind: r

--- a/doc/invoke-json.md
+++ b/doc/invoke-json.md
@@ -34,8 +34,7 @@ specified by prefixing the line with `LEVEL:`. Possible levels are `debug`,
 
 ## Actions
 
-Providers can implement the following actions. Only `describe` must be
-supported.
+Providers can implement the following actions.
 
 * `describe` - describe the provider by outputting YAML metadata
 * `get` - list one or more resources
@@ -57,6 +56,11 @@ inputs described for each action:
 ```
 
 ### The describe action
+
+The `describe` action is used to retrieve metadata about the provider. If
+the provider `script.prov` is accompanied by a file `script.yaml`
+containing the metadata, the `describe` action will never be invoked. If no
+such YAML file exists, the provider must support the `describe` action.
 
 When the describe action is invoked, `stdin` is empty and the provider
 should not try to read from it.

--- a/doc/invoke-simple.md
+++ b/doc/invoke-simple.md
@@ -44,8 +44,7 @@ specified by prefixing the line with `LEVEL:`. Possible levels are `debug`,
 
 ## Actions
 
-Providers can implement the following actions. Only `describe` must be
-supported.
+Providers can implement the following actions.
 
 * `describe` - describe the provider by outputting YAML metadata
 * `list` - list all instances
@@ -54,6 +53,11 @@ supported.
   resource. This action is only called if at least one attribute needs to
   be changed from the value reported by `find name=NAME`, and only
   attributes that have to be changed will be passed to `update`.
+
+The `describe` action is used to retrieve metadata about the provider. If
+the provider `script.prov` is accompanied by a file `script.yaml`
+containing the metadata, the `describe` action will never be invoked. If no
+such YAML file exists, the provider must support the `describe` action.
 
 You can run a provider from the command line with the following
 invocations:

--- a/doc/metadata.md
+++ b/doc/metadata.md
@@ -18,13 +18,31 @@ The entries under `provider` have the following meaning:
 * `type`: the name of the provider's underlying type
 * `invoke`: the calling convention the provider uses. Must be either
   [simple](invoke-simple.md) or [json](invoke-json.md)
-* `actions`: an array listing the actions this provider supports; possible
-  entries in the array are `list`, `find` and `update`
-* `suitable`: either `true` or `false` indicating whether the provider can
-be used on the current system
+* `actions`: an array listing the actions this provider supports; the
+  possible values depend on the calling convention: for the simple calling
+  convention, they are any combination of `list`, `find` and `update`, and
+  for the JSON calling convention they are either `set` or `get` (or both)
+* `suitable`: indicates whether the provider can be used on the target
+  system (see below)
 
 In addition to this data, a provider also needs to describe its attributes
 as defined in [this document](attributes.md).
+
+## Expressing suitability
+
+The `suitable` attribute in the provider metadata can either be the boolean
+`true` or `false`, or a list of commands that must be or must not be
+available. For the latter, the `suitable` attribute would look like:
+
+```yaml
+...
+  suitable:
+    commands: [yum, not dnf]
+...
+```
+
+This indicates that the provider will be suitable if the `yum` command is
+present, and the `dnf` command is not present.
 
 <!--
 #### Digression on suitable/default (later)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PROJECT_SOURCES "src/libral.cc" "src/augeas/handle.cc" "src/augeas/node.cc"
   "src/prov/spec.cc" "src/attr/spec.cc"
   "src/command.cc" "src/resource.cc" "src/context.cc"
   "src/environment.cc"
+  "src/target.cc" "src/target/local.cc" "src/target/ssh.cc"
   "src/emitter/puppet_emitter.cc"
   "src/emitter/json_emitter.cc")
 

--- a/lib/inc/libral/augeas/handle.hpp
+++ b/lib/inc/libral/augeas/handle.hpp
@@ -15,6 +15,8 @@ namespace libral { namespace augeas {
 
   class handle : public std::enable_shared_from_this<handle> {
   public:
+    using callback = std::function<void(::augeas *)>;
+
     ~handle() { aug_close(_augeas); }
 
     /**
@@ -70,14 +72,44 @@ namespace libral { namespace augeas {
      * the node at PATH if it doesn't exist yet.*/
     node make_node_seq_next(const std::string& path);
 
+    /**
+     * Returns a handle to a new augeas instance which will load lenses
+     * from loadpath, a colon separated list of directories. The reader and
+     * writer callbacks are used when the tree needs to be loaded and
+     * saved, making it possible to process files that are not on the local
+     * system; if they are not given, aug_load and aug_save are used for
+     * that.
+     *
+     * The reader must place file contents into the augeas tree, which
+     * should generally happen at /files/$path, e.g. using
+     * aug_text_store. The writer needs to turn the interesting parts of
+     * the tree back into text and store it on disk.
+     *
+     * Both should report errors by setting at least
+     * /augeas/files/$path/error and /augeas/files/$path/error/message to a
+     * machine-readable and a human readable indication of the
+     * error. Additional entries can be set in accordance to what augeas
+     * itself does when it encounters errors.
+     *
+     * When a reader or a writer are provided, the augeas root is set to
+     * /dev/null to make sure that there is no chance of inadvertently
+     * modifying the local filesystem through aug_load and aug_save.
+     *
+     * The reader should take into account that aug_load by default makes
+     * sure that all input text ends with a '\n' (it appends one if there
+     * is none) and that lenses generally expect that newline to be there,
+     * and otherwise might fail on non-newline terminated input.
+     */
     static std::shared_ptr<handle> make(const std::string& loadpath,
-                                        unsigned int flags) {
-      return std::shared_ptr<handle>(new handle(loadpath, flags));
+                                        const callback& reader = nullptr,
+                                        const callback& writer = nullptr) {
+      return std::shared_ptr<handle>(new handle(loadpath, reader, writer));
     }
 
   private:
-    handle(const std::string& loadpath, unsigned int flags)
-      : _augeas(aug_init(NULL, loadpath.c_str(), flags)) { };
+    handle(const std::string& loadpath,
+           const callback& reader,
+           const callback &writer);
 
     /* Checks _augeas for errors and return an error if there is one. */
     result<void> check_error() const;
@@ -86,6 +118,8 @@ namespace libral { namespace augeas {
     /* make_node_seq_next uses this to make sure we create unique sequence
        numbers for nodes that need it */
     int       _seq;
+    callback  _reader;
+    callback  _writer;
   };
 
   } }

--- a/lib/inc/libral/augeas/handle.hpp
+++ b/lib/inc/libral/augeas/handle.hpp
@@ -72,6 +72,8 @@ namespace libral { namespace augeas {
      * the node at PATH if it doesn't exist yet.*/
     node make_node_seq_next(const std::string& path);
 
+    void print(const std::string& path);
+
     /**
      * Returns a handle to a new augeas instance which will load lenses
      * from loadpath, a colon separated list of directories. The reader and

--- a/lib/inc/libral/augeas/node.hpp
+++ b/lib/inc/libral/augeas/node.hpp
@@ -90,6 +90,16 @@ namespace libral { namespace augeas {
     extract_array(resource& res, const std::string& attr,
                   const std::string& label) const;
 
+    /**
+     * Turn the node's path into an absolute path, i.e., one that does not
+     * contain any match constructs anymore. This turns an expression like
+     * /files/etc/hosts/\*[ipaddr= '127.0.0.1'] into /files/etc/hosts/1
+     *
+     * It is an error if the original path does not match exactly one node,
+     * i.e. no node or more than one node
+     */
+    result<void> resolve();
+
   private:
     std::string append(const std::string& p2) const;
 

--- a/lib/inc/libral/command.hpp
+++ b/lib/inc/libral/command.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <vector>
-#include <boost/optional.hpp>
+#include <memory>
+
 #include <libral/result.hpp>
+#include <libral/target.hpp>
 
 namespace libral {
   /** A convenience wrapper around leatherman::execution for running simple
@@ -37,8 +39,7 @@ namespace libral {
       int exit_code = 0;
     };
 
-    /* Create a new command with absolute path cmd */
-    command(const std::string& cmd) : _cmd(cmd) { };
+    command(target::sptr tgt, const std::string& cmd) : _cmd(cmd), _tgt(tgt) { }
 
     /* Run the command with the given args. If the command exits with a
        non-zero exit code, return an error result */
@@ -58,6 +59,7 @@ namespace libral {
                    std::function<bool(std::string&)> stderr_callback = nullptr);
 
   private:
-    std::string _cmd;
+    std::string  _cmd;
+    target::sptr _tgt;
   };
 }

--- a/lib/inc/libral/command.hpp
+++ b/lib/inc/libral/command.hpp
@@ -53,6 +53,8 @@ namespace libral {
     /* Create a new command backed by the script cmd. */
     static boost::optional<command> script(const std::string& cmd);
 
+    bool executable() const;
+
     bool each_line(std::vector<std::string> const& arguments,
                    std::function<bool(std::string&)> stdout_callback,
                    std::function<bool(std::string&)> stderr_callback = nullptr);

--- a/lib/inc/libral/command.hpp
+++ b/lib/inc/libral/command.hpp
@@ -9,13 +9,54 @@ namespace libral {
       commands */
   class command {
   public:
+
+    /**
+     * Encapsulates return value from executing a process.
+     */
+    struct result {
+      result(bool s, std::string o, std::string e, int ec)
+        : success(s), output(move(o)), error(move(e)), exit_code(ec) {}
+
+      /**
+       * Whether or not the command succeeded, defaults to true.
+       */
+      bool success = true;
+      /**
+       * Output from stdout.
+       */
+      std::string output;
+      /**
+       * Output from stderr (if not redirected).
+       */
+      std::string error;
+      /**
+       * The process exit code, defaults to 0.
+       */
+      int exit_code = 0;
+    };
+
     /* Run the command with the given args. If the command exits with a
        non-zero exit code, return an error result */
-    result<void> run(const std::vector<std::string>& args);
+    libral::result<void> run(const std::vector<std::string>& args);
+
+    result execute(const std::vector<std::string>& args);
+
+    result execute(const std::vector<std::string>& args,
+                   const std::string& stdin);
+
+    const std::string& path() const { return _cmd; }
 
     /* Create a new command for running cmd, which will be looked up on the
        PATH */
     static boost::optional<command> create(const std::string& cmd);
+
+    /* Create a new command backed by the script cmd. */
+    static boost::optional<command> script(const std::string& cmd);
+
+    bool each_line(std::vector<std::string> const& arguments,
+                   std::function<bool(std::string&)> stdout_callback,
+                   std::function<bool(std::string&)> stderr_callback = nullptr);
+
   private:
     /* Create a new command with absolute path cmd */
     command(const std::string& cmd) : _cmd(cmd) { };

--- a/lib/inc/libral/command.hpp
+++ b/lib/inc/libral/command.hpp
@@ -10,6 +10,8 @@ namespace libral {
   class command {
   public:
 
+    using uptr = std::unique_ptr<command>;
+
     /**
      * Encapsulates return value from executing a process.
      */
@@ -35,6 +37,9 @@ namespace libral {
       int exit_code = 0;
     };
 
+    /* Create a new command with absolute path cmd */
+    command(const std::string& cmd) : _cmd(cmd) { };
+
     /* Run the command with the given args. If the command exits with a
        non-zero exit code, return an error result */
     libral::result<void> run(const std::vector<std::string>& args);
@@ -46,13 +51,6 @@ namespace libral {
 
     const std::string& path() const { return _cmd; }
 
-    /* Create a new command for running cmd, which will be looked up on the
-       PATH */
-    static boost::optional<command> create(const std::string& cmd);
-
-    /* Create a new command backed by the script cmd. */
-    static boost::optional<command> script(const std::string& cmd);
-
     bool executable() const;
 
     bool each_line(std::vector<std::string> const& arguments,
@@ -60,8 +58,6 @@ namespace libral {
                    std::function<bool(std::string&)> stderr_callback = nullptr);
 
   private:
-    /* Create a new command with absolute path cmd */
-    command(const std::string& cmd) : _cmd(cmd) { };
     std::string _cmd;
   };
 }

--- a/lib/inc/libral/command.hpp
+++ b/lib/inc/libral/command.hpp
@@ -39,7 +39,8 @@ namespace libral {
       int exit_code = 0;
     };
 
-    command(target::sptr tgt, const std::string& cmd) : _cmd(cmd), _tgt(tgt) { }
+    command(target::sptr tgt, const std::string& cmd, bool needs_upload=false)
+      : _cmd(cmd), _tgt(tgt), _needs_upload(needs_upload) { }
 
     /* Run the command with the given args. If the command exits with a
        non-zero exit code, return an error result */
@@ -52,14 +53,17 @@ namespace libral {
 
     const std::string& path() const { return _cmd; }
 
-    bool executable() const;
+    bool executable();
 
     bool each_line(std::vector<std::string> const& arguments,
                    std::function<bool(std::string&)> stdout_callback,
                    std::function<bool(std::string&)> stderr_callback = nullptr);
 
   private:
+    libral::result<void> upload();
+
     std::string  _cmd;
     target::sptr _tgt;
+    bool         _needs_upload;
   };
 }

--- a/lib/inc/libral/environment.hpp
+++ b/lib/inc/libral/environment.hpp
@@ -30,6 +30,8 @@ namespace libral {
 
     libral::command::uptr script(const std::string& cmd);
 
+    std::string which(const std::string& cmd) const;
+
     /**
      * Creates an augeas handle that has the files described by \p xfms
      * loaded.

--- a/lib/inc/libral/environment.hpp
+++ b/lib/inc/libral/environment.hpp
@@ -32,6 +32,8 @@ namespace libral {
 
     std::string which(const std::string& cmd) const;
 
+    bool is_local() const;
+
     /**
      * Creates an augeas handle that has the files described by \p xfms
      * loaded.

--- a/lib/inc/libral/environment.hpp
+++ b/lib/inc/libral/environment.hpp
@@ -28,6 +28,8 @@ namespace libral {
      */
     boost::optional<libral::command> command(const std::string& cmd);
 
+    boost::optional<libral::command> script(const std::string& cmd);
+
     /**
      * Creates an augeas handle that has the files described by \p xfms
      * loaded.

--- a/lib/inc/libral/environment.hpp
+++ b/lib/inc/libral/environment.hpp
@@ -26,9 +26,9 @@ namespace libral {
      * @return \c boost::none if no command \p cmd can be found, or a
      * command object to run this command.
      */
-    boost::optional<libral::command> command(const std::string& cmd);
+    libral::command::uptr command(const std::string& cmd);
 
-    boost::optional<libral::command> script(const std::string& cmd);
+    libral::command::uptr script(const std::string& cmd);
 
     /**
      * Creates an augeas handle that has the files described by \p xfms

--- a/lib/inc/libral/group.hpp
+++ b/lib/inc/libral/group.hpp
@@ -22,10 +22,10 @@ namespace libral {
   private:
     result<void> set(context &ctx, const update &upd);
 
-    boost::optional<command>     _cmd_groupadd;
-    boost::optional<command>     _cmd_groupmod;
-    boost::optional<command>     _cmd_groupdel;
-    std::string                  _data_dir;
+    command::uptr                 _cmd_groupadd;
+    command::uptr                 _cmd_groupmod;
+    command::uptr                 _cmd_groupdel;
+    std::string                   _data_dir;
   };
 
 }

--- a/lib/inc/libral/json_provider.hpp
+++ b/lib/inc/libral/json_provider.hpp
@@ -14,8 +14,8 @@ namespace libral {
     using json_container = leatherman::json_container::JsonContainer;
     using json_keys = std::vector<leatherman::json_container::JsonContainerKey>;
 
-    json_provider(const command &cmd, YAML::Node &node)
-      : provider(), _cmd(cmd), _node(node) { };
+    json_provider(command::uptr& cmd, YAML::Node &node)
+      : provider(), _cmd(std::move(cmd)), _node(node) { };
 
     result<std::vector<resource>>
     get(context& ctx, const std::vector<std::string>& names,
@@ -23,7 +23,7 @@ namespace libral {
 
     result<void> set(context &ctx, const updates& upds) override;
 
-    const std::string& source() const override { return _cmd.path(); }
+    const std::string& source() const override { return _cmd->path(); }
   protected:
     result<prov::spec> describe(environment &env) override;
   private:
@@ -44,7 +44,7 @@ namespace libral {
                     const json_container& json,
                     const json_keys& key);
 
-    command _cmd;
-    YAML::Node _node;
+    command::uptr _cmd;
+    YAML::Node    _node;
   };
 }

--- a/lib/inc/libral/json_provider.hpp
+++ b/lib/inc/libral/json_provider.hpp
@@ -14,8 +14,8 @@ namespace libral {
     using json_container = leatherman::json_container::JsonContainer;
     using json_keys = std::vector<leatherman::json_container::JsonContainerKey>;
 
-    json_provider(const std::string& path, YAML::Node &node)
-      : provider(), _path(path), _node(node) { };
+    json_provider(const command &cmd, YAML::Node &node)
+      : provider(), _cmd(cmd), _node(node) { };
 
     result<std::vector<resource>>
     get(context& ctx, const std::vector<std::string>& names,
@@ -23,7 +23,7 @@ namespace libral {
 
     result<void> set(context &ctx, const updates& upds) override;
 
-    const std::string& source() const override { return _path; }
+    const std::string& source() const override { return _cmd.path(); }
   protected:
     result<prov::spec> describe(environment &env) override;
   private:
@@ -44,7 +44,7 @@ namespace libral {
                     const json_container& json,
                     const json_keys& key);
 
-    std::string _path;
+    command _cmd;
     YAML::Node _node;
   };
 }

--- a/lib/inc/libral/mount.hpp
+++ b/lib/inc/libral/mount.hpp
@@ -58,8 +58,8 @@ namespace libral {
     result<void> flush();
 
     std::shared_ptr<augeas::handle> _aug;
-    boost::optional<command>     _cmd_mount;
-    boost::optional<command>     _cmd_umount;
+    command::uptr                   _cmd_mount;
+    command::uptr                   _cmd_umount;
   };
 
 }

--- a/lib/inc/libral/prov/spec.hpp
+++ b/lib/inc/libral/prov/spec.hpp
@@ -5,7 +5,10 @@
 
 #include <libral/attr/spec.hpp>
 
-namespace libral { namespace prov {
+namespace libral {
+  class environment;
+
+  namespace prov {
   class spec {
   public:
     using attr_spec_map = std::map<std::string, attr::spec>;
@@ -50,7 +53,9 @@ namespace libral { namespace prov {
      * @param name the provider name, used in error messages
      * @param node the parsed YAML document
      */
-    static result<spec> read(const std::string& name, const YAML::Node &node);
+    static result<spec> read(const libral::environment& env,
+                             const std::string& name,
+                             const YAML::Node &node);
 
     /**
      * Reads a provider specification from a string that must contain valid YAML
@@ -58,7 +63,9 @@ namespace libral { namespace prov {
      * @param name the provider name, used in error messages
      * @param yaml the YAML text
      */
-    static result<spec> read(const std::string& name, const std::string &yaml);
+    static result<spec> read(const libral::environment &env,
+                             const std::string& name,
+                             const std::string &yaml);
 
     attr_spec_map::const_iterator attr_begin() const
       { return _attr_specs.cbegin(); }
@@ -69,6 +76,10 @@ namespace libral { namespace prov {
     spec(const std::string& name, const std::string& type,
          const std::string& desc, attr_spec_map&& attr_specs);
     std::string make_qname(const std::string& name, const std::string& type);
+
+    static result<bool>
+    read_suitable(const environment& env,
+                  const YAML::Node& node, const std::string& prov_name);
 
     std::string   _name;
     std::string   _type;

--- a/lib/inc/libral/ral.hpp
+++ b/lib/inc/libral/ral.hpp
@@ -20,15 +20,25 @@ namespace libral {
     /* Create an instance of the RAL */
     static std::shared_ptr<ral> create(std::vector<std::string> data_dirs);
 
+    /* Connect to a remote (ssh) target. The target must be a string that
+     * the ssh command understands, i.e. 'ssh $target uptime' needs to work
+     */
+    result<void> connect(const std::string& _target);
+
     const std::vector<std::string>& data_dirs() const { return _data_dirs; }
 
     boost::optional<std::string>
     find_in_data_dirs(const std::string& file) const;
 
   protected:
+    friend class environment;
+
     ral(const std::vector<std::string>& data_dir);
 
-    environment make_env() { return environment(shared_from_this()); }
+    environment make_env();
+
+    target::sptr target() const { return _target; }
+
   private:
     bool init_provider(environment &env,
                        const std::string& name,
@@ -37,5 +47,6 @@ namespace libral {
                                       const std::string& yaml) const;
     result<std::string> run_describe(command& cmd) const;
     std::vector<std::string> _data_dirs;
+    target::sptr _target;
   };
 }

--- a/lib/inc/libral/ral.hpp
+++ b/lib/inc/libral/ral.hpp
@@ -35,7 +35,7 @@ namespace libral {
                        std::shared_ptr<provider>& prov);
     result<YAML::Node> parse_metadata(const std::string& path,
                                       const std::string& yaml) const;
-    result<std::string> run_describe(const std::string& path) const;
+    result<std::string> run_describe(command& cmd) const;
     std::vector<std::string> _data_dirs;
   };
 }

--- a/lib/inc/libral/ral.hpp
+++ b/lib/inc/libral/ral.hpp
@@ -23,7 +23,8 @@ namespace libral {
     /* Connect to a remote (ssh) target. The target must be a string that
      * the ssh command understands, i.e. 'ssh $target uptime' needs to work
      */
-    result<void> connect(const std::string& _target);
+    result<void> connect(const std::string& _target,
+                         bool sudo = false, bool keep = false);
 
     const std::vector<std::string>& data_dirs() const { return _data_dirs; }
 

--- a/lib/inc/libral/ral.hpp
+++ b/lib/inc/libral/ral.hpp
@@ -45,7 +45,9 @@ namespace libral {
                        std::shared_ptr<provider>& prov);
     result<YAML::Node> parse_metadata(const std::string& path,
                                       const std::string& yaml) const;
+    result<std::string> get_metadata(command& cmd, const std::string& path) const;
     result<std::string> run_describe(command& cmd) const;
+
     std::vector<std::string> _data_dirs;
     target::sptr _target;
   };

--- a/lib/inc/libral/ral.hpp
+++ b/lib/inc/libral/ral.hpp
@@ -39,6 +39,8 @@ namespace libral {
 
     target::sptr target() const { return _target; }
 
+    bool is_local() const { return _local; }
+
   private:
     bool init_provider(environment &env,
                        const std::string& name,
@@ -50,5 +52,6 @@ namespace libral {
 
     std::vector<std::string> _data_dirs;
     target::sptr _target;
+    bool _local;
   };
 }

--- a/lib/inc/libral/simple_provider.hpp
+++ b/lib/inc/libral/simple_provider.hpp
@@ -9,8 +9,8 @@ namespace libral {
      convention */
   class simple_provider : public provider {
   public:
-    simple_provider(const std::string& path, YAML::Node &node)
-      : provider(), _path(path), _node(node) { };
+    simple_provider(command& cmd, YAML::Node &node)
+      : provider(), _cmd(cmd), _node(node) { };
 
     result<std::vector<resource>>
     get(context &ctx,
@@ -19,7 +19,7 @@ namespace libral {
 
     result<void> set(context &ctx, const updates& upds) override;
 
-    const std::string& source() const override { return _path; }
+    const std::string& source() const override { return _cmd.path(); }
   protected:
     result<prov::spec> describe(environment &env) override;
   private:
@@ -31,7 +31,7 @@ namespace libral {
                std::function<result<bool>(std::string&, std::string&)> entry_cb,
                std::vector<std::string> args = {});
 
-    std::string _path;
+    command _cmd;
     YAML::Node _node;
   };
 }

--- a/lib/inc/libral/simple_provider.hpp
+++ b/lib/inc/libral/simple_provider.hpp
@@ -9,8 +9,8 @@ namespace libral {
      convention */
   class simple_provider : public provider {
   public:
-    simple_provider(command& cmd, YAML::Node &node)
-      : provider(), _cmd(cmd), _node(node) { };
+    simple_provider(command::uptr& cmd, YAML::Node &node)
+      : provider(), _cmd(std::move(cmd)), _node(node) { };
 
     result<std::vector<resource>>
     get(context &ctx,
@@ -19,7 +19,7 @@ namespace libral {
 
     result<void> set(context &ctx, const updates& upds) override;
 
-    const std::string& source() const override { return _cmd.path(); }
+    const std::string& source() const override { return _cmd->path(); }
   protected:
     result<prov::spec> describe(environment &env) override;
   private:
@@ -31,7 +31,7 @@ namespace libral {
                std::function<result<bool>(std::string&, std::string&)> entry_cb,
                std::vector<std::string> args = {});
 
-    command _cmd;
-    YAML::Node _node;
+    command::uptr _cmd;
+    YAML::Node    _node;
   };
 }

--- a/lib/inc/libral/target.hpp
+++ b/lib/inc/libral/target.hpp
@@ -3,6 +3,11 @@
 #include <memory>
 
 namespace libral {
+  /**
+   * Classes in this namespace represent different ways to access the
+   * system that we want to manage. For an overview of the API, see
+   * target::base.
+   */
   namespace target {
 
   // Forward declarations to break include loop. All these classes are
@@ -11,8 +16,16 @@ namespace libral {
 
   using sptr = std::shared_ptr<base>;
 
+  /**
+   * Make a local target, i.e. one that accesses files and runs commands
+   * through normal system calls
+   */
   sptr make_local();
 
+  /**
+   * Make an ssh target, i.e. one that accesses files and commands on a
+   * remote system through ssh and scp
+   */
   sptr make_ssh(const std::string& target, bool sudo = false, bool keep = false);
 
   }

--- a/lib/inc/libral/target.hpp
+++ b/lib/inc/libral/target.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <memory>
+
+namespace libral {
+  namespace target {
+
+  // Forward declarations to break include loop. All these classes are
+  // declared in the corresponding files in the target/ subdirectory
+  class base;
+
+  using sptr = std::shared_ptr<base>;
+
+  sptr make_local();
+
+  sptr make_ssh(const std::string& target);
+
+  }
+}

--- a/lib/inc/libral/target.hpp
+++ b/lib/inc/libral/target.hpp
@@ -13,7 +13,7 @@ namespace libral {
 
   sptr make_local();
 
-  sptr make_ssh(const std::string& target);
+  sptr make_ssh(const std::string& target, bool sudo = false, bool keep = false);
 
   }
 }

--- a/lib/inc/libral/target/base.hpp
+++ b/lib/inc/libral/target/base.hpp
@@ -36,6 +36,11 @@ namespace libral {
                            std::vector<std::string> const& args,
                            std::function<bool(std::string&)> out_cb,
                            std::function<bool(std::string&)> err_cb) = 0;
+
+    virtual result<std::string> read(const std::string& remote_path) = 0;
+
+    virtual result<void> write(const std::string& content,
+                               const std::string& remote_path) = 0;
   };
   }
 }

--- a/lib/inc/libral/target/base.hpp
+++ b/lib/inc/libral/target/base.hpp
@@ -12,33 +12,86 @@ namespace libral {
   public:
     virtual ~base() = default;
 
+    /**
+     * Establishes the connection to the target system. This must be called
+     * before any other methods in this class.
+     */
     virtual result<void> connect() = 0;
 
+    /**
+     * Create a new command, i.e. something that can run an executable that
+     * is already on the managed system.
+     */
     virtual libral::command::uptr command(const std::string& cmd) = 0;
 
+    /**
+     * Create a new script, i.e. something that we need to upload from cmd
+     * to the target system so that we can run it there as a command. This
+     * method takes care of uploading and making the uploaded script
+     * executable.
+     */
     virtual libral::command::uptr script(const std::string& cmd) = 0;
 
+    /**
+     * Create an augeas instance that reads and writes files on the
+     * target. The data_dirs are the directories on the local system where
+     * we should look for lenses. The xfms tell us which lenses to use with
+     * what files: for each transformation (pair), the first element names
+     * a lens like Hosts.lns and the second is the absolute path to a
+     * file. Note that globs in filenames are currently not supported.
+     */
     virtual result<std::shared_ptr<augeas::handle>>
     augeas(const std::vector<std::string>& data_dirs,
            const std::vector<std::pair<std::string, std::string>>& xfms) = 0;
 
+    /**
+     * Returns true if file is executable
+     */
     virtual bool executable(const std::string& file) = 0;
 
+    /**
+     * Returns the absolute path to the command cmd. If the command does
+     * not exist, returns an empty string.
+     */
     virtual std::string which(const std::string& cmd) = 0;
 
+    /**
+     * Uploads the local file cmd to a temporary directory and makes it
+     * executable there. Returns the absolute path to that file on the
+     * target on success.
+     */
     virtual result<std::string> upload(const std::string& cmd) = 0;
 
+    /**
+     * Executes the file cmd, passing the command line arguments args and,
+     * optionally, *stdin on stdin. The file cmd must already exist on the
+     * target and be executable.
+     */
     virtual command::result execute(const std::string& cmd,
                                     const std::vector<std::string>& args,
                                     const std::string *stdin = nullptr) = 0;
 
+    /**
+     * Executes the file cmd, passing the command line arguments
+     * args. Calls the callbacks out_cb and err_cb on each line of the
+     * commands stdout and stderr.
+     */
     virtual bool each_line(const std::string& cmd,
                            std::vector<std::string> const& args,
                            std::function<bool(std::string&)> out_cb,
                            std::function<bool(std::string&)> err_cb) = 0;
 
+    /**
+     * Reads a file from the absolute path remote_path on the target and
+     * returns its contents.
+     */
     virtual result<std::string> read(const std::string& remote_path) = 0;
 
+    /**
+     * Writes the file remote_path on that target, putting content into
+     * it. Care is taken to preserve the ownership and permissions of
+     * remote_path if we are overwriting an existing file.
+     */
     virtual result<void> write(const std::string& content,
                                const std::string& remote_path) = 0;
   };

--- a/lib/inc/libral/target/base.hpp
+++ b/lib/inc/libral/target/base.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+
+#include <libral/result.hpp>
+#include <libral/command.hpp>
+#include <libral/augeas.hpp>
+
+namespace libral {
+  namespace target {
+  class base : public std::enable_shared_from_this<base> {
+  public:
+    virtual ~base() = default;
+
+    virtual result<void> connect() = 0;
+
+    virtual libral::command::uptr command(const std::string& cmd) = 0;
+
+    virtual libral::command::uptr script(const std::string& cmd) = 0;
+
+    virtual result<std::shared_ptr<augeas::handle>>
+    augeas(const std::vector<std::string>& data_dirs,
+           const std::vector<std::pair<std::string, std::string>>& xfms) = 0;
+
+    virtual bool executable(const std::string& file) = 0;
+
+    virtual std::string which(const std::string& cmd) = 0;
+
+    virtual result<std::string> upload(const std::string& cmd) = 0;
+
+    virtual command::result execute(const std::string& cmd,
+                                    const std::vector<std::string>& args,
+                                    const std::string *stdin = nullptr) = 0;
+
+    virtual bool each_line(const std::string& cmd,
+                           std::vector<std::string> const& args,
+                           std::function<bool(std::string&)> out_cb,
+                           std::function<bool(std::string&)> err_cb) = 0;
+  };
+  }
+}

--- a/lib/inc/libral/target/local.hpp
+++ b/lib/inc/libral/target/local.hpp
@@ -30,6 +30,12 @@ namespace libral {
                    std::vector<std::string> const& args,
                    std::function<bool(std::string&)> out_cb,
                    std::function<bool(std::string&)> err_cb) override;
+
+    result<std::string> read(const std::string& remote_path) override;
+
+    result<void> write(const std::string& content,
+                       const std::string& remote_path) override;
+
   };
   }
 }

--- a/lib/inc/libral/target/local.hpp
+++ b/lib/inc/libral/target/local.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <libral/target/base.hpp>
+
+namespace libral {
+  namespace target {
+  class local : public base {
+  public:
+    result<void> connect() override;
+
+    libral::command::uptr command(const std::string& cmd) override;
+
+    libral::command::uptr script(const std::string& cmd) override;
+
+    result<std::shared_ptr<augeas::handle>>
+    augeas(const std::vector<std::string>& data_dirs,
+           const std::vector<std::pair<std::string, std::string>>& xfms) override;
+
+    bool executable(const std::string& file) override;
+
+    std::string which(const std::string& cmd) override;
+
+    result<std::string> upload(const std::string& cmd) override;
+
+    command::result execute(const std::string& cmd,
+                            const std::vector<std::string>& args,
+                            const std::string *stdin = nullptr) override;
+
+    bool each_line(const std::string& cmd,
+                   std::vector<std::string> const& args,
+                   std::function<bool(std::string&)> out_cb,
+                   std::function<bool(std::string&)> err_cb) override;
+  };
+  }
+}

--- a/lib/inc/libral/target/ssh.hpp
+++ b/lib/inc/libral/target/ssh.hpp
@@ -39,6 +39,9 @@ namespace libral {
     command::result run(const std::string& file,
                         const std::vector<std::string>& args,
                         const std::string *stdin = nullptr);
+
+    command::result run_ssh(const std::vector<std::string>& args);
+
     std::string _target;
     std::string _tmpdir;
   };

--- a/lib/inc/libral/target/ssh.hpp
+++ b/lib/inc/libral/target/ssh.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <libral/target.hpp>
+#include <libral/target/base.hpp>
+
+namespace libral {
+  namespace target {
+  class ssh : public base {
+  public:
+    ssh(const std::string& target) : _target(target) { }
+    ~ssh();
+
+    result<void> connect() override;
+
+    libral::command::uptr command(const std::string& cmd) override;
+
+    libral::command::uptr script(const std::string& cmd) override;
+
+    result<std::shared_ptr<augeas::handle>>
+    augeas(const std::vector<std::string>& data_dirs,
+           const std::vector<std::pair<std::string, std::string>>& xfms)
+      override;
+
+    bool executable(const std::string& file) override;
+
+    std::string which(const std::string& cmd) override;
+
+    result<std::string> upload(const std::string& cmd) override;
+
+    command::result execute(const std::string& cmd,
+                            const std::vector<std::string>& args,
+                            const std::string *stdin = nullptr) override;
+
+    bool each_line(const std::string& cmd,
+                   std::vector<std::string> const& args,
+                   std::function<bool(std::string&)> out_cb,
+                   std::function<bool(std::string&)> err_cb) override;
+  private:
+    command::result run(const std::string& file,
+                        const std::vector<std::string>& args,
+                        const std::string *stdin = nullptr);
+    std::string _target;
+    std::string _tmpdir;
+  };
+  }
+}

--- a/lib/inc/libral/target/ssh.hpp
+++ b/lib/inc/libral/target/ssh.hpp
@@ -7,7 +7,8 @@ namespace libral {
   namespace target {
   class ssh : public base {
   public:
-    ssh(const std::string& target) : _target(target) { }
+    ssh(const std::string& target, bool sudo = false, bool keep = false)
+      : _target(target), _sudo(sudo), _keep(keep) { }
     ~ssh();
 
     result<void> connect() override;
@@ -44,6 +45,8 @@ namespace libral {
 
     std::string _target;
     std::string _tmpdir;
+    bool _sudo;
+    bool _keep;
   };
   }
 }

--- a/lib/inc/libral/target/ssh.hpp
+++ b/lib/inc/libral/target/ssh.hpp
@@ -41,7 +41,8 @@ namespace libral {
                         const std::vector<std::string>& args,
                         const std::string *stdin = nullptr);
 
-    command::result run_ssh(const std::vector<std::string>& args);
+    command::result run_ssh(const std::vector<std::string>& args,
+                            const std::string *stdin = nullptr);
 
     std::string _target;
     std::string _tmpdir;

--- a/lib/inc/libral/target/ssh.hpp
+++ b/lib/inc/libral/target/ssh.hpp
@@ -36,6 +36,12 @@ namespace libral {
                    std::vector<std::string> const& args,
                    std::function<bool(std::string&)> out_cb,
                    std::function<bool(std::string&)> err_cb) override;
+
+    result<std::string> read(const std::string& remote_path) override;
+
+    result<void> write(const std::string& content,
+                       const std::string& remote_path) override;
+
   private:
     result<std::string> tmpdir();
 

--- a/lib/inc/libral/target/ssh.hpp
+++ b/lib/inc/libral/target/ssh.hpp
@@ -37,6 +37,8 @@ namespace libral {
                    std::function<bool(std::string&)> out_cb,
                    std::function<bool(std::string&)> err_cb) override;
   private:
+    result<std::string> tmpdir();
+
     command::result run(const std::string& file,
                         const std::vector<std::string>& args,
                         const std::string *stdin = nullptr);

--- a/lib/inc/libral/user.hpp
+++ b/lib/inc/libral/user.hpp
@@ -57,9 +57,9 @@ namespace libral {
   private:
     result<void> set(context &ctx, const update& upd);
 
-    boost::optional<command>     _cmd_useradd;
-    boost::optional<command>     _cmd_usermod;
-    boost::optional<command>     _cmd_userdel;
+    command::uptr     _cmd_useradd;
+    command::uptr     _cmd_usermod;
+    command::uptr     _cmd_userdel;
   };
 
 }

--- a/lib/src/augeas/handle.cc
+++ b/lib/src/augeas/handle.cc
@@ -182,4 +182,8 @@ namespace libral { namespace augeas {
     return result<void>();
   }
 
+  void handle::print(const std::string& path) {
+    aug_print(_augeas, stdout, path.c_str());
+  }
+
 } }

--- a/lib/src/augeas/node.cc
+++ b/lib/src/augeas/node.cc
@@ -94,4 +94,16 @@ namespace libral { namespace augeas {
     return result<void>();
   }
 
+  result<void> node::resolve() {
+    auto m = _aug->match(_path);
+    err_ret( m );
+    if (m.ok().size() != 1) {
+      return error(_("Expected {1} to match exactly one node, but it matched {2}",
+                     _path, m.ok().size()));
+    }
+    _path = m.ok().front().path();
+    return result<void>();
+  }
+
+
 } }

--- a/lib/src/command.cc
+++ b/lib/src/command.cc
@@ -56,18 +56,4 @@ namespace libral {
          std::function<bool(std::string&)> err_cb) {
     return leatherman::execution::each_line(_cmd, args, out_cb, err_cb);
   }
-
-  boost::optional<command> command::create(const std::string& cmd) {
-    auto abs_cmd = exe::which(cmd);
-    if (abs_cmd.empty()) {
-      return boost::none;
-    } else {
-      return command(abs_cmd);
-    }
-  }
-
-  boost::optional<command> command::script(const std::string& cmd) {
-    // For remote targets, we need to upload cmd to the target first
-    return create(cmd);
-  }
 }

--- a/lib/src/command.cc
+++ b/lib/src/command.cc
@@ -4,11 +4,16 @@
 
 namespace libral {
 
-  bool command::executable() const {
+  bool command::executable() {
+    auto ret = upload();
+    if (! ret)
+      return false;
     return _tgt->executable(_cmd);
   }
 
   result<void> command::run(const std::vector<std::string> &args) {
+    err_ret( upload() );
+
     auto status = _tgt->execute(_cmd, args);
 
     if (status.success)
@@ -31,18 +36,40 @@ namespace libral {
   }
 
   command::result command::execute(const std::vector<std::string>& args) {
+    auto res = upload();
+    if (!res) {
+      return command::result(false, "Upload failed", res.err().detail, 1);
+    }
     return _tgt->execute(_cmd, args);
   }
 
 
   command::result command::execute(const std::vector<std::string>& args,
                                          const std::string& stdin) {
+    auto res = upload();
+    if (!res) {
+      return command::result(false, "Upload failed", res.err().detail, 1);
+    }
     return _tgt->execute(_cmd, args, &stdin);
   }
 
   bool command::each_line(std::vector<std::string> const& args,
          std::function<bool(std::string&)> out_cb,
          std::function<bool(std::string&)> err_cb) {
+    auto res = upload();
+    if (!res) {
+      return false;
+    }
     return _tgt->each_line(_cmd, args, out_cb, err_cb);
+  }
+
+  libral::result<void> command::upload() {
+    if (_needs_upload) {
+      auto abs_cmd = _tgt->upload(_cmd);
+      err_ret( abs_cmd );
+      _cmd = abs_cmd.ok();
+      _needs_upload = false;
+    }
+    return libral::result<void>();
   }
 }

--- a/lib/src/command.cc
+++ b/lib/src/command.cc
@@ -1,21 +1,15 @@
 #include <libral/command.hpp>
 
-#include <leatherman/execution/execution.hpp>
-#include <leatherman/locale/locale.hpp>
-
-using namespace leatherman::locale;
-namespace exe = leatherman::execution;
+#include <libral/target/base.hpp>
 
 namespace libral {
+
   bool command::executable() const {
-    return access(_cmd.c_str(), X_OK) == 0;
+    return _tgt->executable(_cmd);
   }
 
   result<void> command::run(const std::vector<std::string> &args) {
-    static const lth_util::option_set<exe::execution_options> options = {
-      exe::execution_options::trim_output,
-      exe::execution_options::merge_environment };
-    auto status = exe::execute(_cmd, args, 0, options);
+    auto status = _tgt->execute(_cmd, args);
 
     if (status.success)
       return libral::result<void>();
@@ -37,23 +31,18 @@ namespace libral {
   }
 
   command::result command::execute(const std::vector<std::string>& args) {
-    auto res = exe::execute(_cmd, args, 0, { exe::execution_options::trim_output,
-                                exe::execution_options::merge_environment });
-    return result(res.success, res.output, res.error, res.exit_code);
+    return _tgt->execute(_cmd, args);
   }
 
 
   command::result command::execute(const std::vector<std::string>& args,
-                 const std::string& stdin) {
-    auto res = exe::execute(_cmd, args, stdin,
-                            0, { exe::execution_options::trim_output,
-                                exe::execution_options::merge_environment });
-    return result(res.success, res.output, res.error, res.exit_code);
+                                         const std::string& stdin) {
+    return _tgt->execute(_cmd, args, &stdin);
   }
 
   bool command::each_line(std::vector<std::string> const& args,
          std::function<bool(std::string&)> out_cb,
          std::function<bool(std::string&)> err_cb) {
-    return leatherman::execution::each_line(_cmd, args, out_cb, err_cb);
+    return _tgt->each_line(_cmd, args, out_cb, err_cb);
   }
 }

--- a/lib/src/command.cc
+++ b/lib/src/command.cc
@@ -7,6 +7,10 @@ using namespace leatherman::locale;
 namespace exe = leatherman::execution;
 
 namespace libral {
+  bool command::executable() const {
+    return access(_cmd.c_str(), X_OK) == 0;
+  }
+
   result<void> command::run(const std::vector<std::string> &args) {
     static const lth_util::option_set<exe::execution_options> options = {
       exe::execution_options::trim_output,

--- a/lib/src/command.cc
+++ b/lib/src/command.cc
@@ -14,7 +14,7 @@ namespace libral {
     auto status = exe::execute(_cmd, args, 0, options);
 
     if (status.success)
-      return result<void>();
+      return libral::result<void>();
 
     if (status.output.empty()) {
       if (status.error.empty()) {
@@ -32,6 +32,27 @@ namespace libral {
     }
   }
 
+  command::result command::execute(const std::vector<std::string>& args) {
+    auto res = exe::execute(_cmd, args, 0, { exe::execution_options::trim_output,
+                                exe::execution_options::merge_environment });
+    return result(res.success, res.output, res.error, res.exit_code);
+  }
+
+
+  command::result command::execute(const std::vector<std::string>& args,
+                 const std::string& stdin) {
+    auto res = exe::execute(_cmd, args, stdin,
+                            0, { exe::execution_options::trim_output,
+                                exe::execution_options::merge_environment });
+    return result(res.success, res.output, res.error, res.exit_code);
+  }
+
+  bool command::each_line(std::vector<std::string> const& args,
+         std::function<bool(std::string&)> out_cb,
+         std::function<bool(std::string&)> err_cb) {
+    return leatherman::execution::each_line(_cmd, args, out_cb, err_cb);
+  }
+
   boost::optional<command> command::create(const std::string& cmd) {
     auto abs_cmd = exe::which(cmd);
     if (abs_cmd.empty()) {
@@ -39,5 +60,10 @@ namespace libral {
     } else {
       return command(abs_cmd);
     }
+  }
+
+  boost::optional<command> command::script(const std::string& cmd) {
+    // For remote targets, we need to upload cmd to the target first
+    return create(cmd);
   }
 }

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -34,7 +34,7 @@ namespace libral {
                           const std::string& desc,
                           boost::optional<bool> suitable) {
 
-    auto spec = prov::spec::read(name, desc);
+    auto spec = prov::spec::read(*this, name, desc);
     err_ret(spec);
 
     if (suitable)
@@ -44,6 +44,6 @@ namespace libral {
 
   result<prov::spec>
   environment::parse_spec(const std::string& name, const YAML::Node &node) {
-    return prov::spec::read(name, node);
+    return prov::spec::read(*this, name, node);
   }
 }

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -20,6 +20,10 @@ namespace libral {
     return _ral->target()->script(cmd);
   }
 
+  std::string environment::which(const std::string& cmd) const {
+    return _ral->target()->which(cmd);
+  }
+
   result<std::shared_ptr<augeas::handle>>
   environment::augeas(const std::vector<std::pair<std::string, std::string>>& xfms) {
     return _ral->target()->augeas(data_dirs(), xfms);

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -24,6 +24,10 @@ namespace libral {
     return _ral->target()->which(cmd);
   }
 
+  bool environment::is_local() const {
+    return _ral->is_local();
+  }
+
   result<std::shared_ptr<augeas::handle>>
   environment::augeas(const std::vector<std::pair<std::string, std::string>>& xfms) {
     return _ral->target()->augeas(data_dirs(), xfms);

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -2,6 +2,10 @@
 
 #include <libral/ral.hpp>
 
+#include <leatherman/execution/execution.hpp>
+
+namespace exe = leatherman::execution;
+
 namespace libral {
 
   namespace aug = libral::augeas;
@@ -9,14 +13,20 @@ namespace libral {
   const std::vector<std::string>&
   environment::data_dirs() const { return _ral->data_dirs(); }
 
-  boost::optional<libral::command>
+  libral::command::uptr
   environment::command(const std::string& cmd) {
-    return command::create(cmd);
+    auto abs_cmd = exe::which(cmd);
+    if (abs_cmd.empty()) {
+      return std::unique_ptr<libral::command>();
+    } else {
+      auto raw = new libral::command(abs_cmd);
+      return std::unique_ptr<libral::command>(raw);
+    }
   }
 
-  boost::optional<libral::command>
+  libral::command::uptr
   environment::script(const std::string& cmd) {
-    return command::script(cmd);
+    return command(cmd);
   }
 
   result<std::shared_ptr<augeas::handle>>

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -1,10 +1,7 @@
 #include <libral/environment.hpp>
 
 #include <libral/ral.hpp>
-
-#include <leatherman/execution/execution.hpp>
-
-namespace exe = leatherman::execution;
+#include <libral/target/base.hpp>
 
 namespace libral {
 
@@ -15,40 +12,17 @@ namespace libral {
 
   libral::command::uptr
   environment::command(const std::string& cmd) {
-    auto abs_cmd = exe::which(cmd);
-    if (abs_cmd.empty()) {
-      return std::unique_ptr<libral::command>();
-    } else {
-      auto raw = new libral::command(abs_cmd);
-      return std::unique_ptr<libral::command>(raw);
-    }
+    return _ral->target()->command(cmd);
   }
 
   libral::command::uptr
   environment::script(const std::string& cmd) {
-    return command(cmd);
+    return _ral->target()->script(cmd);
   }
 
   result<std::shared_ptr<augeas::handle>>
   environment::augeas(const std::vector<std::pair<std::string, std::string>>& xfms) {
-
-    std::stringstream buf;
-    bool first=true;
-
-    for (auto dir : data_dirs()) {
-      if (!first)
-        buf << ":";
-      first=false;
-      buf << dir << "/lenses";
-    }
-
-    auto aug = aug::handle::make(buf.str(), AUG_NO_MODL_AUTOLOAD);
-    for (auto& xfm : xfms) {
-      err_ret( aug->include(xfm.first, xfm.second) );
-    }
-    err_ret( aug->load() );
-
-    return aug;
+    return _ral->target()->augeas(data_dirs(), xfms);
   }
 
   result<prov::spec>

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -14,6 +14,11 @@ namespace libral {
     return command::create(cmd);
   }
 
+  boost::optional<libral::command>
+  environment::script(const std::string& cmd) {
+    return command::script(cmd);
+  }
+
   result<std::shared_ptr<augeas::handle>>
   environment::augeas(const std::vector<std::pair<std::string, std::string>>& xfms) {
 

--- a/lib/src/file.cc
+++ b/lib/src/file.cc
@@ -79,7 +79,7 @@ namespace libral {
     static const std::string desc =
 #include "file.yaml"
       ;
-    return env.parse_spec("file", desc);
+    return env.parse_spec("file", desc, env.is_local());
   }
 
   result<std::vector<resource>>

--- a/lib/src/group.cc
+++ b/lib/src/group.cc
@@ -13,10 +13,15 @@ namespace libral {
 #include "group.yaml"
       ;
 
-    _cmd_groupadd = env.command("groupadd");
-    _cmd_groupmod = env.command("groupmod");
-    _cmd_groupdel = env.command("groupdel");
-    auto suitable = _cmd_groupadd && _cmd_groupmod && _cmd_groupdel;
+    auto suitable = env.is_local();
+
+    if (suitable) {
+      _cmd_groupadd = env.command("groupadd");
+      _cmd_groupmod = env.command("groupmod");
+      _cmd_groupdel = env.command("groupdel");
+      suitable = suitable &&
+        _cmd_groupadd && _cmd_groupmod && _cmd_groupdel;
+    }
 
     return env.parse_spec("group", desc, suitable);
   }

--- a/lib/src/host.cc
+++ b/lib/src/host.cc
@@ -8,16 +8,12 @@ namespace libral {
 #include "host.yaml"
       ;
 
-    bool suitable = env.is_local();
+    auto aug = env.augeas({ { "Hosts.lns", "/etc/hosts" } });
+    err_ret(aug);
 
-    if (suitable) {
-      auto aug = env.augeas({ { "Hosts.lns", "/etc/hosts" } });
-      err_ret(aug);
+    _aug = aug.ok();
 
-      _aug = aug.ok();
-    }
-
-    return env.parse_spec("host", desc, suitable);
+    return env.parse_spec("host", desc, true);
   }
 
   result<aug::node>

--- a/lib/src/host.cc
+++ b/lib/src/host.cc
@@ -8,12 +8,16 @@ namespace libral {
 #include "host.yaml"
       ;
 
-    auto aug = env.augeas({ { "Hosts.lns", "/etc/hosts" } });
-    err_ret(aug);
+    bool suitable = env.is_local();
 
-    _aug = aug.ok();
+    if (suitable) {
+      auto aug = env.augeas({ { "Hosts.lns", "/etc/hosts" } });
+      err_ret(aug);
 
-    return env.parse_spec("host", desc, true);
+      _aug = aug.ok();
+    }
+
+    return env.parse_spec("host", desc, suitable);
   }
 
   result<aug::node>

--- a/lib/src/json_provider.cc
+++ b/lib/src/json_provider.cc
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <string>
 
-#include <leatherman/execution/execution.hpp>
 #include <boost/filesystem.hpp>
 
 #include <leatherman/locale/locale.hpp>
@@ -14,7 +13,6 @@
 #include <cstdio>
 
 using namespace leatherman::locale;
-namespace exe = leatherman::execution;
 namespace fs = boost::filesystem;
 namespace json = leatherman::json_container;
 using json_container = json::JsonContainer;
@@ -128,7 +126,7 @@ namespace libral {
   }
 
   result<prov::spec> json_provider::describe(environment &env) {
-    auto name = fs::path(_path).filename().stem();
+    auto name = fs::path(_cmd.path()).filename().stem();
 
     return env.parse_spec(name.native(), _node);
   }
@@ -172,10 +170,7 @@ namespace libral {
                             const json_container& json) {
     auto inp = json.toString();
     ctx.log_debug("passing {1} on stdin", inp);
-    auto res = exe::execute(_path, { "ral_action=" + action },
-                            inp,
-                            0, { exe::execution_options::trim_output,
-                                exe::execution_options::merge_environment });
+    auto res = _cmd.execute({ "ral_action=" + action }, inp);
     if (!res.error.empty()) {
       // FIXME: this should really happen in a callback while the command
       // is running rather than after the command finished. For that, we'd

--- a/lib/src/json_provider.cc
+++ b/lib/src/json_provider.cc
@@ -126,7 +126,7 @@ namespace libral {
   }
 
   result<prov::spec> json_provider::describe(environment &env) {
-    auto name = fs::path(_cmd.path()).filename().stem();
+    auto name = fs::path(_cmd->path()).filename().stem();
 
     return env.parse_spec(name.native(), _node);
   }
@@ -170,7 +170,7 @@ namespace libral {
                             const json_container& json) {
     auto inp = json.toString();
     ctx.log_debug("passing {1} on stdin", inp);
-    auto res = _cmd.execute({ "ral_action=" + action }, inp);
+    auto res = _cmd->execute({ "ral_action=" + action }, inp);
     if (!res.error.empty()) {
       // FIXME: this should really happen in a callback while the command
       // is running rather than after the command finished. For that, we'd

--- a/lib/src/mount.cc
+++ b/lib/src/mount.cc
@@ -31,7 +31,10 @@ namespace libral {
 
   aug::node mount_provider::base(const update &upd) {
     if (upd.present()) {
-      return _aug->make_node("/files/etc/fstab/*[file = '" + upd.name() + "']");
+      auto res =
+        _aug->make_node("/files/etc/fstab/*[file = '" + upd.name() + "']");
+      res.resolve();
+      return res;
     } else {
       return _aug->make_node_seq_next("/files/etc/fstab");
     }

--- a/lib/src/mount.cc
+++ b/lib/src/mount.cc
@@ -15,20 +15,16 @@ namespace libral {
 #include "mount.yaml"
       ;
 
-    bool suitable = env.is_local();
+    auto aug = env.augeas({ { "Mount_Fstab.lns", "/etc/fstab" },
+                            { "Mount_Fstab.lns", "/etc/mtab"  } });
+    err_ret(aug);
 
-    if (suitable) {
-      auto aug = env.augeas({ { "Mount_Fstab.lns", "/etc/fstab" },
-                              { "Mount_Fstab.lns", "/etc/mtab"  } });
-      err_ret(aug);
+    _aug = aug.ok();
 
-      _aug = aug.ok();
+    _cmd_mount = env.command("mount");
+    _cmd_umount = env.command("umount");
 
-      _cmd_mount = env.command("mount");
-      _cmd_umount = env.command("umount");
-
-      suitable = suitable && _cmd_mount && _cmd_umount;
-    }
+    auto suitable = _cmd_mount && _cmd_umount;
 
     return env.parse_spec("mount", desc, suitable);
   }

--- a/lib/src/mount.cc
+++ b/lib/src/mount.cc
@@ -15,16 +15,20 @@ namespace libral {
 #include "mount.yaml"
       ;
 
-    auto aug = env.augeas({ { "Mount_Fstab.lns", "/etc/fstab" },
-                            { "Mount_Fstab.lns", "/etc/mtab"  } });
-    err_ret(aug);
+    bool suitable = env.is_local();
 
-    _aug = aug.ok();
+    if (suitable) {
+      auto aug = env.augeas({ { "Mount_Fstab.lns", "/etc/fstab" },
+                              { "Mount_Fstab.lns", "/etc/mtab"  } });
+      err_ret(aug);
 
-    _cmd_mount = env.command("mount");
-    _cmd_umount = env.command("umount");
+      _aug = aug.ok();
 
-    auto suitable = _cmd_mount && _cmd_umount;
+      _cmd_mount = env.command("mount");
+      _cmd_umount = env.command("umount");
+
+      suitable = suitable && _cmd_mount && _cmd_umount;
+    }
 
     return env.parse_spec("mount", desc, suitable);
   }

--- a/lib/src/ral.cc
+++ b/lib/src/ral.cc
@@ -137,9 +137,9 @@ namespace libral {
       if (invoke == "simple" || invoke == "json") {
         provider *raw_prov;
         if (invoke == "simple") {
-          raw_prov = new simple_provider(*cmd, node);
+          raw_prov = new simple_provider(cmd, node);
         } else {
-          raw_prov = new json_provider(*cmd, node);
+          raw_prov = new json_provider(cmd, node);
         }
         auto prov = std::shared_ptr<provider>(raw_prov);
         if (init_provider(env, type_name, prov)) {

--- a/lib/src/ral.cc
+++ b/lib/src/ral.cc
@@ -31,8 +31,8 @@ namespace libral {
     return fs::absolute(fs::path(path)).native();
   }
 
-  result<void> ral::connect(const std::string& target) {
-    auto tgt = target::make_ssh(target);
+  result<void> ral::connect(const std::string& target, bool sudo, bool keep) {
+    auto tgt = target::make_ssh(target, sudo, keep);
     auto res = tgt->connect();
     if (res.is_ok()) {
       _local = false;

--- a/lib/src/ral.cc
+++ b/lib/src/ral.cc
@@ -221,7 +221,7 @@ namespace libral {
   }
 
   result<std::string> ral::run_describe(command& cmd) const {
-    if (access(cmd.path().c_str(), X_OK) == 0) {
+    if (cmd.executable()) {
       auto res = cmd.execute({ "ral_action=describe" });
       if (!res.success) {
         if (res.output.empty()) {

--- a/lib/src/ral.cc
+++ b/lib/src/ral.cc
@@ -81,6 +81,8 @@ namespace libral {
       // This is extremely strange .. no path ?
       util::environment::set("PATH", env_libexec_dir);
     }
+    util::environment::reload_search_paths();
+
     // FIXME: Check that mruby is there and warn otherwise
 
     auto handle = new ral(data_dirs);

--- a/lib/src/ral.cc
+++ b/lib/src/ral.cc
@@ -2,6 +2,8 @@
 
 #include <config.hpp>
 
+#include <fstream>
+
 #include <libral/mount.hpp>
 #include <libral/user.hpp>
 #include <libral/group.hpp>

--- a/lib/src/ral.cc
+++ b/lib/src/ral.cc
@@ -35,6 +35,7 @@ namespace libral {
     auto tgt = target::make_ssh(target);
     auto res = tgt->connect();
     if (res.is_ok()) {
+      _local = false;
       _target = tgt;
     }
     return res;
@@ -88,7 +89,7 @@ namespace libral {
   }
 
   ral::ral(const std::vector<std::string>& data_dirs)
-    : _data_dirs(data_dirs), _target(target::make_local()) {
+    : _data_dirs(data_dirs), _target(target::make_local()), _local(true) {
     _target->connect();
   }
 

--- a/lib/src/simple_provider.cc
+++ b/lib/src/simple_provider.cc
@@ -62,7 +62,7 @@ namespace libral {
   }
 
   result<prov::spec> simple_provider::describe(environment &env) {
-    auto name = fs::path(_cmd.path()).filename().stem();
+    auto name = fs::path(_cmd->path()).filename().stem();
 
     return env.parse_spec(name.native(), _node);
   }
@@ -177,14 +177,14 @@ namespace libral {
       }
       return rslt.is_ok();
     };
-    auto r = _cmd.each_line(args, out_cb, err_cb);
+    auto r = _cmd->each_line(args, out_cb, err_cb);
     if (! r && rslt.is_ok()) {
       if (errmsg.empty()) {
         rslt = error(_("Something went wrong running %s ral_action=%s",
-                       _cmd.path(), action));
+                       _cmd->path(), action));
       } else {
         rslt = error(_("Something went wrong running %s ral_action=%s\n%s",
-                       _cmd.path(), action, errmsg));
+                       _cmd->path(), action, errmsg));
       }
     }
     return rslt;

--- a/lib/src/simple_provider.cc
+++ b/lib/src/simple_provider.cc
@@ -62,7 +62,7 @@ namespace libral {
   }
 
   result<prov::spec> simple_provider::describe(environment &env) {
-    auto name = fs::path(_path).filename().stem();
+    auto name = fs::path(_cmd.path()).filename().stem();
 
     return env.parse_spec(name.native(), _node);
   }
@@ -177,14 +177,14 @@ namespace libral {
       }
       return rslt.is_ok();
     };
-    auto r = leatherman::execution::each_line(_path, args, out_cb, err_cb);
+    auto r = _cmd.each_line(args, out_cb, err_cb);
     if (! r && rslt.is_ok()) {
       if (errmsg.empty()) {
         rslt = error(_("Something went wrong running %s ral_action=%s",
-                       _path, action));
+                       _cmd.path(), action));
       } else {
         rslt = error(_("Something went wrong running %s ral_action=%s\n%s",
-                       _path, action, errmsg));
+                       _cmd.path(), action, errmsg));
       }
     }
     return rslt;

--- a/lib/src/target.cc
+++ b/lib/src/target.cc
@@ -10,8 +10,9 @@ namespace libral {
     return std::shared_ptr<local>(new local());
   }
 
-  std::shared_ptr<base> make_ssh(const std::string& target) {
-    return std::shared_ptr<ssh>(new ssh(target));
+  std::shared_ptr<base> make_ssh(const std::string& target,
+                                 bool sudo, bool keep) {
+    return std::shared_ptr<ssh>(new ssh(target, sudo, keep));
   }
   }
 }

--- a/lib/src/target.cc
+++ b/lib/src/target.cc
@@ -1,0 +1,17 @@
+#include <libral/target.hpp>
+
+#include <libral/target/base.hpp>
+#include <libral/target/local.hpp>
+#include <libral/target/ssh.hpp>
+
+namespace libral {
+  namespace target {
+  std::shared_ptr<base> make_local() {
+    return std::shared_ptr<local>(new local());
+  }
+
+  std::shared_ptr<base> make_ssh(const std::string& target) {
+    return std::shared_ptr<ssh>(new ssh(target));
+  }
+  }
+}

--- a/lib/src/target/local.cc
+++ b/lib/src/target/local.cc
@@ -2,6 +2,9 @@
 
 #include <unistd.h>
 
+#include <sstream>
+#include <fstream>
+
 #include <leatherman/execution/execution.hpp>
 
 namespace exe = leatherman::execution;
@@ -88,5 +91,20 @@ namespace libral {
                         std::function<bool(std::string&)> err_cb) {
     return exe::each_line(cmd, args, out_cb, err_cb);
   }
+
+  result<std::string> local::read(const std::string& remote_path) {
+    std::ifstream file(remote_path);
+    std::ostringstream buf;
+    buf << file.rdbuf();
+    return buf.str();
+  }
+
+  result<void> local::write(const std::string& content,
+                            const std::string& remote_path) {
+    std::ofstream file(remote_path);
+    file << content;
+    return result<void>();
+  }
+
   }
 }

--- a/lib/src/target/local.cc
+++ b/lib/src/target/local.cc
@@ -44,7 +44,7 @@ namespace libral {
       buf << dir << "/lenses";
     }
 
-    auto aug = aug::handle::make(buf.str(), AUG_NO_MODL_AUTOLOAD);
+    auto aug = aug::handle::make(buf.str());
     for (auto& xfm : xfms) {
       err_ret( aug->include(xfm.first, xfm.second) );
     }

--- a/lib/src/target/local.cc
+++ b/lib/src/target/local.cc
@@ -1,0 +1,92 @@
+#include <libral/target/local.hpp>
+
+#include <unistd.h>
+
+#include <leatherman/execution/execution.hpp>
+
+namespace exe = leatherman::execution;
+namespace aug = libral::augeas;
+
+namespace libral {
+  namespace target {
+
+  result<void> local::connect() {
+    return result<void>();
+  }
+
+  libral::command::uptr local::command(const std::string& cmd) {
+    auto abs_cmd = which(cmd);
+    if (abs_cmd.empty()) {
+      return std::unique_ptr<libral::command>();
+    } else {
+      auto raw = new libral::command(shared_from_this(), abs_cmd);
+      return std::unique_ptr<libral::command>(raw);
+    }
+  }
+
+  libral::command::uptr local::script(const std::string& cmd) {
+    return command(cmd);
+  }
+
+  result<std::shared_ptr<augeas::handle>>
+  local::augeas(const std::vector<std::string>& data_dirs,
+                const std::vector<std::pair<std::string, std::string>>& xfms) {
+    std::stringstream buf;
+    bool first=true;
+
+    for (auto dir : data_dirs) {
+      if (!first)
+        buf << ":";
+      first=false;
+      buf << dir << "/lenses";
+    }
+
+    auto aug = aug::handle::make(buf.str(), AUG_NO_MODL_AUTOLOAD);
+    for (auto& xfm : xfms) {
+      err_ret( aug->include(xfm.first, xfm.second) );
+    }
+    err_ret( aug->load() );
+
+    return aug;
+  }
+
+  bool local::executable(const std::string& file) {
+    return access(file.c_str(), X_OK) == 0;
+  }
+
+  std::string local::which(const std::string& cmd) {
+    return exe::which(cmd);
+  }
+
+  result<std::string> local::upload(const std::string& cmd) {
+    return cmd;
+  }
+
+  static command::result as_command_result(const exe::result& res) {
+    return command::result(res.success, res.output, res.error, res.exit_code);
+  }
+
+  command::result local::execute(const std::string& cmd,
+                                 const std::vector<std::string>& args,
+                                 const std::string *stdin) {
+    if (stdin == nullptr) {
+      auto res = exe::execute(cmd, args,
+                              0, { exe::execution_options::trim_output,
+                                  exe::execution_options::merge_environment });
+      return as_command_result(res);
+    } else {
+      auto res = exe::execute(cmd, args, *stdin,
+                              0, { exe::execution_options::trim_output,
+                                  exe::execution_options::merge_environment });
+      return as_command_result(res);
+    }
+  }
+
+  bool local::each_line(const std::string& cmd,
+                        std::vector<std::string> const& args,
+                        std::function<bool(std::string&)> out_cb,
+                        std::function<bool(std::string&)> err_cb) {
+    return exe::each_line(cmd, args, out_cb, err_cb);
+  }
+  }
+}

--- a/lib/src/target/ssh.cc
+++ b/lib/src/target/ssh.cc
@@ -22,13 +22,8 @@ namespace libral {
   }
 
   libral::command::uptr ssh::script(const std::string& cmd) {
-    auto abs_cmd = upload(cmd);
-    if (abs_cmd.is_ok()) {
-      auto raw = new libral::command(shared_from_this(), abs_cmd.ok());
-      return libral::command::uptr(raw);
-    } else {
-      return libral::command::uptr();
-    }
+    auto raw = new libral::command(shared_from_this(), cmd, true);
+    return libral::command::uptr(raw);
   }
 
   result<std::shared_ptr<augeas::handle>>

--- a/lib/src/target/ssh.cc
+++ b/lib/src/target/ssh.cc
@@ -1,0 +1,172 @@
+#include <libral/target/ssh.hpp>
+
+#include <boost/filesystem.hpp>
+
+#include <leatherman/execution/execution.hpp>
+
+namespace exe = leatherman::execution;
+namespace fs = boost::filesystem;
+
+namespace libral {
+  namespace target {
+
+  libral::command::uptr ssh::command(const std::string& cmd) {
+    auto abs_cmd = which(cmd);
+    if (abs_cmd.empty()) {
+      return libral::command::uptr();
+    } else {
+      auto raw = new libral::command(shared_from_this(), abs_cmd);
+      return libral::command::uptr(raw);
+    }
+  }
+
+  libral::command::uptr ssh::script(const std::string& cmd) {
+    auto abs_cmd = upload(cmd);
+    if (abs_cmd.is_ok()) {
+      auto raw = new libral::command(shared_from_this(), abs_cmd.ok());
+      return libral::command::uptr(raw);
+    } else {
+      return libral::command::uptr();
+    }
+  }
+
+  result<std::shared_ptr<augeas::handle>>
+  ssh::augeas(const std::vector<std::string>& data_dirs,
+              const std::vector<std::pair<std::string, std::string>>& xfms) {
+#if 0
+    std::stringstream buf;
+    bool first=true;
+
+    for (auto dir : data_dirs()) {
+      if (!first)
+        buf << ":";
+      first=false;
+      buf << dir << "/lenses";
+    }
+
+    // FIXME: set augeas root to something where we won't hurt anything
+    auto aug = aug::handle::make(buf.str(), AUG_NO_MODL_AUTOLOAD);
+    for (auto& xfm : xfms) {
+      auto text = conn->read(xfm.second);
+      auto in = "/in" + xfm.second;
+      aug.set(in, text);
+      aug.store(xfm.first, in, "/files" + xfm.second);
+    }
+#endif
+    // FIXME: need to make aug.save() run aug.retrieve() and conn.write()
+    // Maybe also make aug.load() redirect reading files through conn
+    return not_implemented_error();
+  }
+
+  bool ssh::executable(const std::string& file) {
+    // We make commands executable when we upload them; the whole check is
+    // probably a bit silly and we might just want to get rid of this
+    // method.
+    return true;
+  }
+
+  static const std::vector<std::string> ssh_opts = {
+    "-o", "ControlMaster=auto",
+    "-o", "ControlPersist=60s",
+    "-o", "ControlPath=~/.ssh/cm-%r@%h:%p" };
+
+  /*
+    ControlMaster handling:
+    start: ssh -f -M -S /socket _target sleep 3600
+    check: ssh -O check -S /socket _target
+    use: ssh -S /socket _target uptime
+    stop: ssh -O stop -S /socket _target
+   */
+
+  result<void> ssh::connect() {
+    static const std::string token = "inlikeflynn";
+    auto res = run("ssh", { _target, "/bin/echo", token });
+    if (res.success && res.output == token) {
+      return result<void>();
+    } else {
+      return error(res.output + "\n" + res.error);
+    }
+  }
+
+  ssh::~ssh() {
+    if (! _tmpdir.empty()) {
+      run("ssh", { _target, "rm", "-rf", _tmpdir});
+    }
+  }
+
+  std::string ssh::which(const std::string& cmd) {
+    auto res = run("ssh", { _target, "which", cmd });
+    if (res.success) {
+      return res.output;
+    } else {
+      return "";
+    }
+  }
+
+  result<std::string> ssh::upload(const std::string& cmd) {
+    if (_tmpdir.empty()) {
+      auto res = run("ssh", { _target, "mktemp", "-t", "-d", "ralXXXXXX"});
+      if (! res.success) {
+        return error(res.error);
+      }
+      _tmpdir = res.output;
+    }
+    auto path = (fs::path(_tmpdir) / fs::path(cmd).filename()).native();
+    auto res = run("scp", {"-pq", cmd, _target + ":" + path});
+    if (! res.success) {
+      return error(res.error);
+    }
+    res = run("ssh", {_target, "chmod", "a+x", path });
+    if (! res.success) {
+      return error(res.error);
+    }
+    return path;
+  }
+
+  command::result ssh::execute(const std::string& cmd,
+                                      const std::vector<std::string>& args,
+                                      const std::string *stdin) {
+    std::vector<std::string> actual;
+    actual.push_back(_target);
+    actual.push_back(cmd);
+    for (auto& arg : args) {
+      actual.push_back(arg);
+    }
+    return run("ssh", actual, stdin);
+  }
+
+  bool ssh::each_line(const std::string& cmd,
+                      std::vector<std::string> const& args,
+                      std::function<bool(std::string&)> out_cb,
+                      std::function<bool(std::string&)> err_cb) {
+    std::vector<std::string> actual;
+    actual.push_back(_target);
+    actual.push_back(cmd);
+    for (auto& arg : args) {
+      actual.push_back(arg);
+    }
+    return exe::each_line("ssh", actual, out_cb, err_cb);
+  }
+
+  command::result ssh::run(const std::string& file,
+                           const std::vector<std::string>& args,
+                           const std::string *stdin) {
+    std::vector<std::string> actual = ssh_opts;
+    for (auto& arg : args) {
+      actual.push_back(arg);
+    }
+
+    if (stdin == nullptr) {
+      auto res = exe::execute(file, actual, 20,
+                              { exe::execution_options::trim_output,
+                                  exe::execution_options::merge_environment });
+      return command::result(res.success, res.output, res.error, res.exit_code);
+    } else {
+      auto res = exe::execute(file, actual, *stdin, 20,
+                         { exe::execution_options::trim_output,
+                             exe::execution_options::merge_environment });
+      return command::result(res.success, res.output, res.error, res.exit_code);
+    }
+  }
+  }
+}

--- a/lib/src/target/ssh.cc
+++ b/lib/src/target/ssh.cc
@@ -155,14 +155,15 @@ namespace libral {
     return exe::each_line("ssh", actual, out_cb, err_cb);
   }
 
-  command::result ssh::run_ssh(const std::vector<std::string>& args) {
+  command::result ssh::run_ssh(const std::vector<std::string>& args,
+                               const std::string *stdin) {
     std::vector<std::string> actual;
     actual.push_back(_target);
     if (_sudo) {
       actual.push_back(sudo);
     }
     actual.insert(actual.end(), args.begin(), args.end());
-    return run("ssh", actual);
+    return run("ssh", actual, stdin);
   }
 
   command::result ssh::run(const std::string& file,

--- a/lib/src/user.cc
+++ b/lib/src/user.cc
@@ -23,11 +23,16 @@ namespace libral {
 #include "user.yaml"
       ;
 
-    _cmd_useradd = env.command("useradd");
-    _cmd_usermod = env.command("usermod");
-    _cmd_userdel = env.command("userdel");
+    auto suitable = env.is_local();
 
-    auto suitable = _cmd_useradd && _cmd_usermod && _cmd_userdel;
+    if (suitable) {
+      _cmd_useradd = env.command("useradd");
+      _cmd_usermod = env.command("usermod");
+      _cmd_userdel = env.command("userdel");
+
+      suitable = suitable &&
+        _cmd_useradd && _cmd_usermod && _cmd_userdel;
+    }
 
     return env.parse_spec("user", desc, suitable);
   }


### PR DESCRIPTION
This makes it possible to access a remote system that has nothing (or not very much) in terms of prerequisites on it. A [prebuilt tarball](http://download.augeas.net/libral/ralsh-remote.tar.gz) is available that makes it possible to use these changes on a system.  After downloading, unpack it somewhere and run `./ral/bin/ralsh`; it will work on any glibc based Linux machine (e.g., CentOS 6 and 7). See `ralsh --help` for usage information, especially the new `--target` and `--sudo` options.

Remote access is purely through the ssh and scp command line tools, and makes heavy use of control sockets to reuse an existing session.

Requirements to use this:
* the controller must have ssh and scp installed
* passwordless access to the remote node must be possible
* the remote node must have `which`, `rm`, `mv`, `chown`, `chmod`, `mktemp`, and `dd` on it (these could mostly be removed by using `sftp` instead of `scp`)

Providers are properly checked for suitability; notice how running `ralsh` and `ralsh -t somehost` will list different providers; several providers (`file::posix`, `user::useradd`, and `group::groupadd`) have not been adapted to remote use.

External providers (scripts like `systemd.prov`) are uploaded to the target system and run there, internal providers like `host` and `mount` simply retrieve files from the target and process them on the controller (and write them back to the remote) Such providers also run commands 'over the wire'; e.g., the `mount` provider will run `mount`/`umount` via ssh. Also, the `package::dnf` provider is broken right now and fails.

The interface for dealing with a remote system is defined in [target/base.hpp](https://github.com/lutter/libral/blob/94841ed2aa379a92b1c6cb051a15b9611b8044f5/lib/inc/libral/target/base.hpp) and the implementation of ssh access is in [target/ssh.cc](https://github.com/lutter/libral/blob/94841ed2aa379a92b1c6cb051a15b9611b8044f5/lib/src/target/ssh.cc)

One thing that makes this slow is that currently the provider lifecycle forces providers to eagerly load files they need to process. That part of the API needs to be improved to separate listing and interrogating provider metadata from full provider initialization. Even with that, `ralsh` is quite usable even with a system 40ms away.

Making the remaining providers work:
* `user` and `group` need to stop using POSIX API's to access `/etc/passwd` and `/etc/group` and instead use Augeas for that; other than that, they follow the same pattens as `host` and `mount`
* `file` requires that the target API be expanded. Some aspects of file management (e.g., reading permissions) will require additional capabilities in that interface, some operations, like managing SELinux context, will always be hard.
* the `dnf` provider requires that we upload more than one file per provider as it is split across two files
* the `ssh_authorized_key` provider is written in mruby; we can instrument mruby similar to what the `target` classes do to make that work (or, of course, upload an mruby interpreter to the target)
