### PR TITLE
(DI-895) Add upstart provider for Ubuntu 14.04 hosts

### DIFF
--- a/data/providers/upstart.prov
+++ b/data/providers/upstart.prov
@@ -1,0 +1,154 @@
+#! /bin/bash
+
+# A provider for SysV-style init systems
+
+# Very important so that sorting goes right
+export LANG=C
+
+svc_path=/etc/init
+
+# die MESSAGE
+# Print an error message and exit
+die() {
+    echo "ral_error: $1"
+    echo "ral_eom"
+    exit 0
+}
+
+is_suitable() {
+    [ -d /etc/init ] || return 1
+    type -p service initctl > /dev/null || return 1
+    # Do not use this provider if systemd is installed
+    type -p systemctl > /dev/null && return 1
+    return 0
+}
+
+describe() {
+    local suitable
+    is_suitable && suitable=true || suitable=false
+    cat <<EOF
+---
+provider:
+  type: service
+  invoke: simple
+  actions: [list,find,update]
+  suitable: ${suitable}
+  attributes:
+    name:
+      type: string
+    ensure:
+      type: enum[running, stopped]
+    enable:
+      type: enum[true, false]
+EOF
+}
+
+# Determine the state of the resource with name $name
+find_state() {
+    [ -z "$name" ] && die "find: missing a name"
+
+    if [ -f "/etc/init/${name}.conf" ]; then
+        egrep "start/running" <(initctl status docker) >/dev/null 2>&1
+        [ $? -eq 0 ] && is_ensure=running || is_ensure=stopped
+        egrep "manual" "/etc/init/${name}.override" >/dev/null 2>&1
+        [ $? -eq 0 ] && is_enable=false || is_enable=true
+    else
+        is_unknown=true
+    fi
+}
+
+list() {
+    local name is_ensure is_enable
+
+    echo '# simple'
+
+    for svc in $svc_path/*.conf
+    do
+        name=$(basename $svc .conf)
+        find_state
+        echo "name: $name"
+        echo "ensure: $is_ensure"
+        echo "enable: $is_enable"
+    done
+}
+
+find() {
+    echo "# simple"
+    find_state
+    echo "name: $name"
+    if [ -z "$is_unknown" ]
+    then
+        echo "ensure: $is_ensure"
+        echo "enable: $is_enable"
+    else
+        echo "ral_unknown: true"
+    fi
+}
+
+# Convenience wrapper to make supporting noop easier
+run() {
+    if [ -z "$ral_noop" ]
+    then
+        msg=$("$@" 2>&1)
+        rc=$?
+        if [ $rc != 0 ]; then
+            die "$msg"
+        fi
+    fi
+}
+
+update() {
+    echo '# simple'
+    echo 'ral_derive: true'
+    find_state
+
+    if [ -n "$is_unknown" ]
+    then
+        echo "ral_unknown: true"
+        exit 0
+    fi
+
+    # Check enablement
+    if [ -n "$enable" ]
+    then
+        case $enable
+        in
+            true)
+                run chkconfig --level 0123456 $name on
+                ;;
+            false)
+                run chkconfig --level 0123456 $name off
+                ;;
+            *) die "illegal value for enable: '$enable'"
+               ;;
+        esac
+    fi
+
+    if [ -n "$ensure" ]
+    then
+        case $ensure
+        in
+            running)
+                run service $name start
+                ;;
+            stopped)
+                run service $name stop
+                ;;
+            *)
+                die "illegal value for ensure: '$ensure'"
+                ;;
+        esac
+    fi
+}
+
+eval "$@"
+
+case "$ral_action"
+in
+    list) list;;
+    find) find;;
+    update) update;;
+    describe) describe;;
+    *)
+        die "Unknown action: $ral_action"
+esac

--- a/data/providers/upstart.prov
+++ b/data/providers/upstart.prov
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# A provider for SysV-style init systems
+# A provider for upstart systems
 
 # Very important so that sorting goes right
 export LANG=C
@@ -48,7 +48,7 @@ find_state() {
     [ -z "$name" ] && die "find: missing a name"
 
     if [ -f "/etc/init/${name}.conf" ]; then
-        egrep "start/running" <(initctl status docker) >/dev/null 2>&1
+        egrep "start/running" <(initctl status ${name}) >/dev/null 2>&1
         [ $? -eq 0 ] && is_ensure=running || is_ensure=stopped
         egrep "manual" "/etc/init/${name}.override" >/dev/null 2>&1
         [ $? -eq 0 ] && is_enable=false || is_enable=true
@@ -114,10 +114,10 @@ update() {
         case $enable
         in
             true)
-                run chkconfig --level 0123456 $name on
+                run rm /etc/init/${name}.override
                 ;;
             false)
-                run chkconfig --level 0123456 $name off
+                run echo "manual" > /etc/init/${name}.override
                 ;;
             *) die "illegal value for enable: '$enable'"
                ;;
@@ -129,10 +129,10 @@ update() {
         case $ensure
         in
             running)
-                run service $name start
+                run initctl start $name 
                 ;;
             stopped)
-                run service $name stop
+                run initctl stop $name
                 ;;
             *)
                 die "illegal value for ensure: '$ensure'"


### PR DESCRIPTION
Currently libral has no service providers for upstart.  This means ubuntu 14.04 hosts
cannot return a list of services.

This provider uses the upstart initctl to list all services and identify if they are
running and enabled.

To test,
1) create a Ubuntu 14.04 host.  
2) Copy the libral archive and unpack.
3) Run `ral/bin/ralsh service`
You should see the following error
unknown provider: 'service'
4) Copy the upstart.prov to the ral/data/providers folder
5) Run `ral/bin/ralsh service`

All the services should be listed