### PR TITLE
Integrate mruby more tightly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,10 @@ add_subdirectory(lib)
 add_subdirectory(exe)
 add_subdirectory(ruby)
 
+# Whether we should assume that our data dir etc. are at a fixed location
+# relative to the executable (for static builds)
+set(USE_FIXED_LAYOUT ${LIBRAL_STATIC})
+
 configure_file("${PROJECT_SOURCE_DIR}/bin/dev.in"
                "${PROJECT_BINARY_DIR}/bin/dev")
 configure_file("${PROJECT_SOURCE_DIR}/config.hpp.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.2.2)
 project(libral VERSION 0.0.1)
 
 # Whether to build a static executable. Only works with pl-build-tools for
-# now since Fedora is missing augeas-static, icu-static, and yaml-cpp-static
+# now since Fedora is missing augeas-static and icu-static
 option(LIBRAL_STATIC "Build a static executable")
 
 # The default data dir. Providers should be placed into
@@ -29,9 +29,6 @@ endif()
 enable_testing()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-
-option(YAMLCPP_STATIC "Use yaml-cpp's static libraries" ${LIBRAL_STATIC})
-find_package(YAMLCPP REQUIRED)
 
 # Leatherman setup
 SET(LEATHERMAN_COMPONENTS locale catch nowide logging execution json_container)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,9 @@ endif()
 include(FeatureSummary)
 feature_summary(WHAT ALL)
 
+add_subdirectory(mruby)
 add_subdirectory(lib)
 add_subdirectory(exe)
-add_subdirectory(mruby)
 add_subdirectory(ruby)
 
 configure_file("${PROJECT_SOURCE_DIR}/bin/dev.in"

--- a/HACKING.md
+++ b/HACKING.md
@@ -15,7 +15,7 @@ Linux distros if you adjust for differences in package names.
     dnf -y install gcc-c++ cmake make gettext boost-devel    \
       curl-devel yaml-cpp-devel augeas-devel ruby rake bison \
       rubygem-bundler rubygem-yard rubygem-rake-compiler     \
-      ruby-devel redhat-rpm-config
+      ruby-devel redhat-rpm-config readline-devel
 ```
 
 You will also need to have `ruby` and `rake` installed, as the embedded

--- a/config.hpp.in
+++ b/config.hpp.in
@@ -5,3 +5,5 @@
 #define LIBRAL_LIBEXEC_DIR "@LIBRAL_LIBEXEC_DIR@"
 
 #cmakedefine HAS_SUGGEST_OVERRIDE 1
+
+#cmakedefine USE_FIXED_LAYOUT

--- a/contrib/docker/scripts/image.sh
+++ b/contrib/docker/scripts/image.sh
@@ -38,7 +38,7 @@ then
     dnf install -y git gcc-c++ cmake make gettext boost-devel \
       curl-devel yaml-cpp-devel augeas-devel ruby rake bison  \
       rubygem-bundler rubygem-yard rubygem-rake-compiler      \
-      ruby-devel redhat-rpm-config
+      ruby-devel redhat-rpm-config readline-devel
     dnf clean all
 elif [ $BUILD_TYPE = el6-build-static ]
 then

--- a/contrib/statpack
+++ b/contrib/statpack
@@ -26,7 +26,7 @@ githash=$(cd $srcdir && git describe --always)
 # Assemble stuff in ral/
 rm -rf ral
 mkdir -p ral/bin
-cp ./bin/ralsh ral/bin/ralsh.bin
+cp ./bin/ralsh ral/bin
 
 cat > ral/README <<EOF
 This is a statically linked build of https://github.com/puppetlabs/libral.
@@ -75,18 +75,8 @@ if [ -n "$UPX" ]
 then
     $UPX -qq ral/bin/*
 fi
-ln ral/bin/ralsh.bin ral/bin/mirb
-ln ral/bin/ralsh.bin ral/bin/mruby
-
-# Add a wrapper to make sure we run with the right setup
-cat > ral/bin/ralsh <<'EOF'
-#! /bin/sh
-topdir=$(readlink -f $(dirname $0)/..)
-export RALSH_DATA_DIR=$topdir/data
-export RALSH_LIBEXEC_DIR=$topdir/bin
-exec $topdir/bin/ralsh.bin "$@"
-EOF
-chmod a+x ral/bin/ralsh
+ln ral/bin/ralsh ral/bin/mirb
+ln ral/bin/ralsh ral/bin/mruby
 
 tarball=ralsh-$(date +%Y-%m-%dT%H.%M)-$githash.tgz
 tar czf $tarball ral

--- a/contrib/statpack
+++ b/contrib/statpack
@@ -27,7 +27,6 @@ githash=$(cd $srcdir && git describe --always)
 rm -rf ral
 mkdir -p ral/bin
 cp ./bin/ralsh ral/bin/ralsh.bin
-cp ./bin/mruby ./bin/mirb ral/bin
 
 cat > ral/README <<EOF
 This is a statically linked build of https://github.com/puppetlabs/libral.
@@ -76,6 +75,8 @@ if [ -n "$UPX" ]
 then
     $UPX -qq ral/bin/*
 fi
+ln ral/bin/ralsh.bin ral/bin/mirb
+ln ral/bin/ralsh.bin ral/bin/mruby
 
 # Add a wrapper to make sure we run with the right setup
 cat > ral/bin/ralsh <<'EOF'

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -15,8 +15,7 @@ include_directories(
 )
 
 link_directories(
-  ${Boost_LIBRARY_DIRS}
-  ${YAMLCPP_LIBRARY_DIRS})
+  ${Boost_LIBRARY_DIRS})
 
 add_executable(ralsh ralsh.cc mruby.c mirb.c)
 target_link_libraries(ralsh libral)

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -11,14 +11,23 @@ include_directories(
     ${Boost_INCLUDE_DIRS}
     ${LIBXML2_INCLUDE_DIRS}
     ${LEATHERMAN_INCLUDE_DIRS}
+    ${MRUBY_INCLUDE_DIRS}
 )
-
-add_executable(ralsh ralsh.cc)
-target_link_libraries(ralsh libral)
 
 link_directories(
   ${Boost_LIBRARY_DIRS}
   ${YAMLCPP_LIBRARY_DIRS})
+
+add_executable(ralsh ralsh.cc mruby.c mirb.c)
+target_link_libraries(ralsh libral)
+
+add_custom_command(
+  TARGET ralsh
+  POST_BUILD
+  WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/bin"
+  COMMAND ln;-f;ralsh;mirb
+  COMMAND ln;-f;ralsh;mruby
+)
 
 leatherman_install(ralsh)
 

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -17,8 +17,15 @@ include_directories(
 link_directories(
   ${Boost_LIBRARY_DIRS})
 
+if (LIBRAL_STATIC)
+  set(READLINE_LIBS readline.a ncurses.a tinfo.a)
+else(LIBRAL_STATIC)
+  set(READLINE_LIBS readline)
+endif(LIBRAL_STATIC)
+
+add_definitions("-DENABLE_READLINE")
 add_executable(ralsh ralsh.cc mruby.c mirb.c)
-target_link_libraries(ralsh libral)
+target_link_libraries(ralsh libral ${READLINE_LIBS})
 
 add_custom_command(
   TARGET ralsh

--- a/exe/mirb.c
+++ b/exe/mirb.c
@@ -1,0 +1,591 @@
+/*
+** mirb - Embeddable Interactive Ruby Shell
+**
+** This program takes code from the user in
+** an interactive way and executes it
+** immediately. It's a REPL...
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#include <signal.h>
+#include <setjmp.h>
+
+#ifdef ENABLE_READLINE
+#include <readline/readline.h>
+#include <readline/history.h>
+#define MIRB_ADD_HISTORY(line) add_history(line)
+#define MIRB_READLINE(ch) readline(ch)
+#define MIRB_WRITE_HISTORY(path) write_history(path)
+#define MIRB_READ_HISTORY(path) read_history(path)
+#define MIRB_USING_HISTORY() using_history()
+#elif defined(ENABLE_LINENOISE)
+#define ENABLE_READLINE
+#include <linenoise.h>
+#define MIRB_ADD_HISTORY(line) linenoiseHistoryAdd(line)
+#define MIRB_READLINE(ch) linenoise(ch)
+#define MIRB_WRITE_HISTORY(path) linenoiseHistorySave(path)
+#define MIRB_READ_HISTORY(path) linenoiseHistoryLoad(history_path)
+#define MIRB_USING_HISTORY()
+#endif
+
+#ifndef _WIN32
+#define MIRB_SIGSETJMP(env) sigsetjmp(env, 1)
+#define MIRB_SIGLONGJMP(env, val) siglongjmp(env, val)
+#define SIGJMP_BUF sigjmp_buf
+#else
+#define MIRB_SIGSETJMP(env) setjmp(env)
+#define MIRB_SIGLONGJMP(env, val) longjmp(env, val)
+#define SIGJMP_BUF jmp_buf
+#endif
+
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/proc.h>
+#include <mruby/compile.h>
+#include <mruby/string.h>
+
+#ifdef ENABLE_READLINE
+
+static const char history_file_name[] = ".mirb_history";
+
+static char *
+get_history_path(mrb_state *mrb)
+{
+  char *path = NULL;
+  const char *home = getenv("HOME");
+
+#ifdef _WIN32
+  if (home != NULL) {
+    home = getenv("USERPROFILE");
+  }
+#endif
+
+  if (home != NULL) {
+    int len = snprintf(NULL, 0, "%s/%s", home, history_file_name);
+    if (len >= 0) {
+      size_t size = len + 1;
+      path = (char *)mrb_malloc_simple(mrb, size);
+      if (path != NULL) {
+        int n = snprintf(path, size, "%s/%s", home, history_file_name);
+        if (n != len) {
+          mrb_free(mrb, path);
+          path = NULL;
+        }
+      }
+    }
+  }
+
+  return path;
+}
+
+#endif
+
+static void
+p(mrb_state *mrb, mrb_value obj, int prompt)
+{
+  mrb_value val;
+
+  val = mrb_funcall(mrb, obj, "inspect", 0);
+  if (prompt) {
+    if (!mrb->exc) {
+      fputs(" => ", stdout);
+    }
+    else {
+      val = mrb_funcall(mrb, mrb_obj_value(mrb->exc), "inspect", 0);
+    }
+  }
+  if (!mrb_string_p(val)) {
+    val = mrb_obj_as_string(mrb, obj);
+  }
+  fwrite(RSTRING_PTR(val), RSTRING_LEN(val), 1, stdout);
+  putc('\n', stdout);
+}
+
+/* Guess if the user might want to enter more
+ * or if he wants an evaluation of his code now */
+static mrb_bool
+is_code_block_open(struct mrb_parser_state *parser)
+{
+  mrb_bool code_block_open = FALSE;
+
+  /* check for heredoc */
+  if (parser->parsing_heredoc != NULL) return TRUE;
+  if (parser->heredoc_end_now) {
+    parser->heredoc_end_now = FALSE;
+    return FALSE;
+  }
+
+  /* check for unterminated string */
+  if (parser->lex_strterm) return TRUE;
+
+  /* check if parser error are available */
+  if (0 < parser->nerr) {
+    const char unexpected_end[] = "syntax error, unexpected $end";
+    const char *message = parser->error_buffer[0].message;
+
+    /* a parser error occur, we have to check if */
+    /* we need to read one more line or if there is */
+    /* a different issue which we have to show to */
+    /* the user */
+
+    if (strncmp(message, unexpected_end, sizeof(unexpected_end) - 1) == 0) {
+      code_block_open = TRUE;
+    }
+    else if (strcmp(message, "syntax error, unexpected keyword_end") == 0) {
+      code_block_open = FALSE;
+    }
+    else if (strcmp(message, "syntax error, unexpected tREGEXP_BEG") == 0) {
+      code_block_open = FALSE;
+    }
+    return code_block_open;
+  }
+
+  switch (parser->lstate) {
+
+  /* all states which need more code */
+
+  case EXPR_BEG:
+    /* beginning of a statement, */
+    /* that means previous line ended */
+    code_block_open = FALSE;
+    break;
+  case EXPR_DOT:
+    /* a message dot was the last token, */
+    /* there has to come more */
+    code_block_open = TRUE;
+    break;
+  case EXPR_CLASS:
+    /* a class keyword is not enough! */
+    /* we need also a name of the class */
+    code_block_open = TRUE;
+    break;
+  case EXPR_FNAME:
+    /* a method name is necessary */
+    code_block_open = TRUE;
+    break;
+  case EXPR_VALUE:
+    /* if, elsif, etc. without condition */
+    code_block_open = TRUE;
+    break;
+
+  /* now all the states which are closed */
+
+  case EXPR_ARG:
+    /* an argument is the last token */
+    code_block_open = FALSE;
+    break;
+
+  /* all states which are unsure */
+
+  case EXPR_CMDARG:
+    break;
+  case EXPR_END:
+    /* an expression was ended */
+    break;
+  case EXPR_ENDARG:
+    /* closing parenthese */
+    break;
+  case EXPR_ENDFN:
+    /* definition end */
+    break;
+  case EXPR_MID:
+    /* jump keyword like break, return, ... */
+    break;
+  case EXPR_MAX_STATE:
+    /* don't know what to do with this token */
+    break;
+  default:
+    /* this state is unexpected! */
+    break;
+  }
+
+  return code_block_open;
+}
+
+struct _args {
+  FILE *rfp;
+  mrb_bool verbose      : 1;
+  int argc;
+  char** argv;
+};
+
+static void
+usage(const char *name)
+{
+  static const char *const usage_msg[] = {
+  "switches:",
+  "-v           print version number, then run in verbose mode",
+  "--verbose    run in verbose mode",
+  "--version    print the version",
+  "--copyright  print the copyright",
+  NULL
+  };
+  const char *const *p = usage_msg;
+
+  printf("Usage: %s [switches]\n", name);
+  while (*p)
+    printf("  %s\n", *p++);
+}
+
+static int
+parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
+{
+  static const struct _args args_zero = { 0 };
+
+  *args = args_zero;
+
+  for (argc--,argv++; argc > 0; argc--,argv++) {
+    char *item;
+    if (argv[0][0] != '-') break;
+
+    item = argv[0] + 1;
+    switch (*item++) {
+    case 'v':
+      if (!args->verbose) mrb_show_version(mrb);
+      args->verbose = TRUE;
+      break;
+    case '-':
+      if (strcmp((*argv) + 2, "version") == 0) {
+        mrb_show_version(mrb);
+        exit(EXIT_SUCCESS);
+      }
+      else if (strcmp((*argv) + 2, "verbose") == 0) {
+        args->verbose = TRUE;
+        break;
+      }
+      else if (strcmp((*argv) + 2, "copyright") == 0) {
+        mrb_show_copyright(mrb);
+        exit(EXIT_SUCCESS);
+      }
+    default:
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (args->rfp == NULL) {
+    if (*argv != NULL) {
+      args->rfp = fopen(argv[0], "r");
+      if (args->rfp == NULL) {
+        printf("Cannot open program file. (%s)\n", *argv);
+        return EXIT_FAILURE;
+      }
+      argc--; argv++;
+    }
+  }
+  args->argv = (char **)mrb_realloc(mrb, args->argv, sizeof(char*) * (argc + 1));
+  memcpy(args->argv, argv, (argc+1) * sizeof(char*));
+  args->argc = argc;
+
+  return EXIT_SUCCESS;
+}
+
+static void
+cleanup(mrb_state *mrb, struct _args *args)
+{
+  if (args->rfp)
+    fclose(args->rfp);
+  mrb_free(mrb, args->argv);
+  mrb_close(mrb);
+}
+
+/* Print a short remark for the user */
+static void
+print_hint(void)
+{
+  printf("mirb - Embeddable Interactive Ruby Shell\n\n");
+}
+
+#ifndef ENABLE_READLINE
+/* Print the command line prompt of the REPL */
+static void
+print_cmdline(int code_block_open)
+{
+  if (code_block_open) {
+    printf("* ");
+  }
+  else {
+    printf("> ");
+  }
+  fflush(stdout);
+}
+#endif
+
+void mrb_codedump_all(mrb_state*, struct RProc*);
+
+static int
+check_keyword(const char *buf, const char *word)
+{
+  const char *p = buf;
+  size_t len = strlen(word);
+
+  /* skip preceding spaces */
+  while (*p && isspace((unsigned char)*p)) {
+    p++;
+  }
+  /* check keyword */
+  if (strncmp(p, word, len) != 0) {
+    return 0;
+  }
+  p += len;
+  /* skip trailing spaces */
+  while (*p) {
+    if (!isspace((unsigned char)*p)) return 0;
+    p++;
+  }
+  return 1;
+}
+
+
+#ifndef ENABLE_READLINE
+volatile sig_atomic_t input_canceled = 0;
+void
+ctrl_c_handler(int signo)
+{
+  input_canceled = 1;
+}
+#else
+SIGJMP_BUF ctrl_c_buf;
+void
+ctrl_c_handler(int signo)
+{
+  MIRB_SIGLONGJMP(ctrl_c_buf, 1);
+}
+#endif
+
+int
+prog_mirb(int argc, char **argv)
+{
+  char ruby_code[4096] = { 0 };
+  char last_code_line[1024] = { 0 };
+#ifndef ENABLE_READLINE
+  int last_char;
+  size_t char_index;
+#else
+  char *history_path;
+  char* line;
+#endif
+  mrbc_context *cxt;
+  struct mrb_parser_state *parser;
+  mrb_state *mrb;
+  mrb_value result;
+  struct _args args;
+  mrb_value ARGV;
+  int n;
+  int i;
+  mrb_bool code_block_open = FALSE;
+  int ai;
+  unsigned int stack_keep = 0;
+
+  /* new interpreter instance */
+  mrb = mrb_open();
+  if (mrb == NULL) {
+    fputs("Invalid mrb interpreter, exiting mirb\n", stderr);
+    return EXIT_FAILURE;
+  }
+
+  n = parse_args(mrb, argc, argv, &args);
+  if (n == EXIT_FAILURE) {
+    cleanup(mrb, &args);
+    usage(argv[0]);
+    return n;
+  }
+
+  ARGV = mrb_ary_new_capa(mrb, args.argc);
+  for (i = 0; i < args.argc; i++) {
+    char* utf8 = mrb_utf8_from_locale(args.argv[i], -1);
+    if (utf8) {
+      mrb_ary_push(mrb, ARGV, mrb_str_new_cstr(mrb, utf8));
+      mrb_utf8_free(utf8);
+    }
+  }
+  mrb_define_global_const(mrb, "ARGV", ARGV);
+
+#ifdef ENABLE_READLINE
+  history_path = get_history_path(mrb);
+  if (history_path == NULL) {
+    fputs("failed to get history path\n", stderr);
+    mrb_close(mrb);
+    return EXIT_FAILURE;
+  }
+
+  MIRB_USING_HISTORY();
+  MIRB_READ_HISTORY(history_path);
+#endif
+
+  print_hint();
+
+  cxt = mrbc_context_new(mrb);
+  cxt->capture_errors = TRUE;
+  cxt->lineno = 1;
+  mrbc_filename(mrb, cxt, "(mirb)");
+  if (args.verbose) cxt->dump_result = TRUE;
+
+  ai = mrb_gc_arena_save(mrb);
+
+  while (TRUE) {
+    char *utf8;
+
+    if (args.rfp) {
+      if (fgets(last_code_line, sizeof(last_code_line)-1, args.rfp) != NULL)
+        goto done;
+      break;
+    }
+
+#ifndef ENABLE_READLINE
+    print_cmdline(code_block_open);
+
+    signal(SIGINT, ctrl_c_handler);
+    char_index = 0;
+    while ((last_char = getchar()) != '\n') {
+      if (last_char == EOF) break;
+      if (char_index >= sizeof(last_code_line)-2) {
+        fputs("input string too long\n", stderr);
+        continue;
+      }
+      last_code_line[char_index++] = last_char;
+    }
+    signal(SIGINT, SIG_DFL);
+    if (input_canceled) {
+      ruby_code[0] = '\0';
+      last_code_line[0] = '\0';
+      code_block_open = FALSE;
+      puts("^C");
+      input_canceled = 0;
+      continue;
+    }
+    if (last_char == EOF) {
+      fputs("\n", stdout);
+      break;
+    }
+
+    last_code_line[char_index++] = '\n';
+    last_code_line[char_index] = '\0';
+#else
+    if (MIRB_SIGSETJMP(ctrl_c_buf) == 0) {
+      ;
+    }
+    else {
+      ruby_code[0] = '\0';
+      last_code_line[0] = '\0';
+      code_block_open = FALSE;
+      puts("^C");
+    }
+    signal(SIGINT, ctrl_c_handler);
+    line = MIRB_READLINE(code_block_open ? "* " : "> ");
+    signal(SIGINT, SIG_DFL);
+
+    if (line == NULL) {
+      printf("\n");
+      break;
+    }
+    if (strlen(line) > sizeof(last_code_line)-2) {
+      fputs("input string too long\n", stderr);
+      continue;
+    }
+    strcpy(last_code_line, line);
+    strcat(last_code_line, "\n");
+    MIRB_ADD_HISTORY(line);
+    free(line);
+#endif
+
+done:
+
+    if (code_block_open) {
+      if (strlen(ruby_code)+strlen(last_code_line) > sizeof(ruby_code)-1) {
+        fputs("concatenated input string too long\n", stderr);
+        continue;
+      }
+      strcat(ruby_code, last_code_line);
+    }
+    else {
+      if (check_keyword(last_code_line, "quit") || check_keyword(last_code_line, "exit")) {
+        break;
+      }
+      strcpy(ruby_code, last_code_line);
+    }
+
+    utf8 = mrb_utf8_from_locale(ruby_code, -1);
+    if (!utf8) abort();
+
+    /* parse code */
+    parser = mrb_parser_new(mrb);
+    if (parser == NULL) {
+      fputs("create parser state error\n", stderr);
+      break;
+    }
+    parser->s = utf8;
+    parser->send = utf8 + strlen(utf8);
+    parser->lineno = cxt->lineno;
+    mrb_parser_parse(parser, cxt);
+    code_block_open = is_code_block_open(parser);
+    mrb_utf8_free(utf8);
+
+    if (code_block_open) {
+      /* no evaluation of code */
+    }
+    else {
+      if (0 < parser->nerr) {
+        /* syntax error */
+        printf("line %d: %s\n", parser->error_buffer[0].lineno, parser->error_buffer[0].message);
+      }
+      else {
+        /* generate bytecode */
+        struct RProc *proc = mrb_generate_code(mrb, parser);
+        if (proc == NULL) {
+          fputs("codegen error\n", stderr);
+          mrb_parser_free(parser);
+          break;
+        }
+
+        if (args.verbose) {
+          mrb_codedump_all(mrb, proc);
+        }
+        /* adjest stack length of toplevel environment */
+        if (mrb->c->cibase->env) {
+          struct REnv *e = mrb->c->cibase->env;
+          if (MRB_ENV_STACK_LEN(e) < proc->body.irep->nlocals) {
+            MRB_SET_ENV_STACK_LEN(e, proc->body.irep->nlocals);
+          }
+        }
+        /* pass a proc for evaluation */
+        /* evaluate the bytecode */
+        result = mrb_vm_run(mrb,
+            proc,
+            mrb_top_self(mrb),
+            stack_keep);
+        stack_keep = proc->body.irep->nlocals;
+        /* did an exception occur? */
+        if (mrb->exc) {
+          p(mrb, mrb_obj_value(mrb->exc), 0);
+          mrb->exc = 0;
+        }
+        else {
+          /* no */
+          if (!mrb_respond_to(mrb, result, mrb_intern_lit(mrb, "inspect"))){
+            result = mrb_any_to_s(mrb, result);
+          }
+          p(mrb, result, 1);
+        }
+      }
+      ruby_code[0] = '\0';
+      last_code_line[0] = '\0';
+      mrb_gc_arena_restore(mrb, ai);
+    }
+    mrb_parser_free(parser);
+    cxt->lineno++;
+  }
+
+#ifdef ENABLE_READLINE
+  MIRB_WRITE_HISTORY(history_path);
+  mrb_free(mrb, history_path);
+#endif
+
+  mrbc_context_free(mrb, cxt);
+  mrb_close(mrb);
+
+  return 0;
+}

--- a/exe/mruby.c
+++ b/exe/mruby.c
@@ -1,0 +1,254 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/compile.h>
+#include <mruby/dump.h>
+#include <mruby/variable.h>
+
+#ifdef MRB_DISABLE_STDIO
+static void
+p(mrb_state *mrb, mrb_value obj)
+{
+  mrb_value val = mrb_inspect(mrb, obj);
+
+  fwrite(RSTRING_PTR(val), RSTRING_LEN(val), 1, stdout);
+  putc('\n', stdout);
+}
+#else
+#define p(mrb,obj) mrb_p(mrb,obj)
+#endif
+
+struct _args {
+  FILE *rfp;
+  char* cmdline;
+  mrb_bool fname        : 1;
+  mrb_bool mrbfile      : 1;
+  mrb_bool check_syntax : 1;
+  mrb_bool verbose      : 1;
+  int argc;
+  char** argv;
+};
+
+static void
+usage(const char *name)
+{
+  static const char *const usage_msg[] = {
+  "switches:",
+  "-b           load and execute RiteBinary (mrb) file",
+  "-c           check syntax only",
+  "-e 'command' one line of script",
+  "-v           print version number, then run in verbose mode",
+  "--verbose    run in verbose mode",
+  "--version    print the version",
+  "--copyright  print the copyright",
+  NULL
+  };
+  const char *const *p = usage_msg;
+
+  printf("Usage: %s [switches] programfile\n", name);
+  while (*p)
+    printf("  %s\n", *p++);
+}
+
+static int
+parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
+{
+  char **origargv = argv;
+  static const struct _args args_zero = { 0 };
+
+  *args = args_zero;
+
+  for (argc--,argv++; argc > 0; argc--,argv++) {
+    char *item;
+    if (argv[0][0] != '-') break;
+
+    if (strlen(*argv) <= 1) {
+      argc--; argv++;
+      args->rfp = stdin;
+      break;
+    }
+
+    item = argv[0] + 1;
+    switch (*item++) {
+    case 'b':
+      args->mrbfile = TRUE;
+      break;
+    case 'c':
+      args->check_syntax = TRUE;
+      break;
+    case 'e':
+      if (item[0]) {
+        goto append_cmdline;
+      }
+      else if (argc > 1) {
+        argc--; argv++;
+        item = argv[0];
+append_cmdline:
+        if (!args->cmdline) {
+          size_t buflen;
+          char *buf;
+
+          buflen = strlen(item) + 1;
+          buf = (char *)mrb_malloc(mrb, buflen);
+          memcpy(buf, item, buflen);
+          args->cmdline = buf;
+        }
+        else {
+          size_t cmdlinelen;
+          size_t itemlen;
+
+          cmdlinelen = strlen(args->cmdline);
+          itemlen = strlen(item);
+          args->cmdline =
+            (char *)mrb_realloc(mrb, args->cmdline, cmdlinelen + itemlen + 2);
+          args->cmdline[cmdlinelen] = '\n';
+          memcpy(args->cmdline + cmdlinelen + 1, item, itemlen + 1);
+        }
+      }
+      else {
+        printf("%s: No code specified for -e\n", *origargv);
+        return EXIT_SUCCESS;
+      }
+      break;
+    case 'v':
+      if (!args->verbose) mrb_show_version(mrb);
+      args->verbose = TRUE;
+      break;
+    case '-':
+      if (strcmp((*argv) + 2, "version") == 0) {
+        mrb_show_version(mrb);
+        exit(EXIT_SUCCESS);
+      }
+      else if (strcmp((*argv) + 2, "verbose") == 0) {
+        args->verbose = TRUE;
+        break;
+      }
+      else if (strcmp((*argv) + 2, "copyright") == 0) {
+        mrb_show_copyright(mrb);
+        exit(EXIT_SUCCESS);
+      }
+    default:
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (args->rfp == NULL && args->cmdline == NULL) {
+    if (*argv == NULL) args->rfp = stdin;
+    else {
+      args->rfp = fopen(argv[0], args->mrbfile ? "rb" : "r");
+      if (args->rfp == NULL) {
+        printf("%s: Cannot open program file. (%s)\n", *origargv, *argv);
+        return EXIT_FAILURE;
+      }
+      args->fname = TRUE;
+      args->cmdline = argv[0];
+      argc--; argv++;
+    }
+  }
+  args->argv = (char **)mrb_realloc(mrb, args->argv, sizeof(char*) * (argc + 1));
+  memcpy(args->argv, argv, (argc+1) * sizeof(char*));
+  args->argc = argc;
+
+  return EXIT_SUCCESS;
+}
+
+static void
+cleanup(mrb_state *mrb, struct _args *args)
+{
+  if (args->rfp && args->rfp != stdin)
+    fclose(args->rfp);
+  if (!args->fname)
+    mrb_free(mrb, args->cmdline);
+  mrb_free(mrb, args->argv);
+  mrb_close(mrb);
+}
+
+int
+prog_mruby(int argc, char **argv)
+{
+  mrb_state *mrb = mrb_open();
+  int n = -1;
+  int i;
+  struct _args args;
+  mrb_value ARGV;
+  mrbc_context *c;
+  mrb_value v;
+  mrb_sym zero_sym;
+
+  if (mrb == NULL) {
+    fputs("Invalid mrb_state, exiting mruby\n", stderr);
+    return EXIT_FAILURE;
+  }
+
+  n = parse_args(mrb, argc, argv, &args);
+  if (n == EXIT_FAILURE || (args.cmdline == NULL && args.rfp == NULL)) {
+    cleanup(mrb, &args);
+    usage(argv[0]);
+    return n;
+  }
+  else {
+    int ai = mrb_gc_arena_save(mrb);
+    ARGV = mrb_ary_new_capa(mrb, args.argc);
+    for (i = 0; i < args.argc; i++) {
+      char* utf8 = mrb_utf8_from_locale(args.argv[i], -1);
+      if (utf8) {
+        mrb_ary_push(mrb, ARGV, mrb_str_new_cstr(mrb, utf8));
+        mrb_utf8_free(utf8);
+      }
+    }
+    mrb_define_global_const(mrb, "ARGV", ARGV);
+
+    c = mrbc_context_new(mrb);
+    if (args.verbose)
+      c->dump_result = TRUE;
+    if (args.check_syntax)
+      c->no_exec = TRUE;
+
+    /* Set $0 */
+    zero_sym = mrb_intern_lit(mrb, "$0");
+    if (args.rfp) {
+      const char *cmdline;
+      cmdline = args.cmdline ? args.cmdline : "-";
+      mrbc_filename(mrb, c, cmdline);
+      mrb_gv_set(mrb, zero_sym, mrb_str_new_cstr(mrb, cmdline));
+    }
+    else {
+      mrbc_filename(mrb, c, "-e");
+      mrb_gv_set(mrb, zero_sym, mrb_str_new_lit(mrb, "-e"));
+    }
+
+    /* Load program */
+    if (args.mrbfile) {
+      v = mrb_load_irep_file_cxt(mrb, args.rfp, c);
+    }
+    else if (args.rfp) {
+      v = mrb_load_file_cxt(mrb, args.rfp, c);
+    }
+    else {
+      char* utf8 = mrb_utf8_from_locale(args.cmdline, -1);
+      if (!utf8) abort();
+      v = mrb_load_string_cxt(mrb, utf8, c);
+      mrb_utf8_free(utf8);
+    }
+
+    mrb_gc_arena_restore(mrb, ai);
+    mrbc_context_free(mrb, c);
+    if (mrb->exc) {
+      if (mrb_undef_p(v)) {
+        mrb_p(mrb, mrb_obj_value(mrb->exc));
+      }
+      else {
+        mrb_print_error(mrb);
+      }
+      n = -1;
+    }
+    else if (args.check_syntax) {
+      printf("Syntax OK\n");
+    }
+  }
+  cleanup(mrb, &args);
+
+  return n == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/exe/ralsh.cc
+++ b/exe/ralsh.cc
@@ -130,7 +130,31 @@ static void print_explanation(lib::provider& prov) {
   }
 }
 
+std::string progname(const char* argv0) {
+  const char *progname = rindex(argv0, '/');
+  if (progname == NULL) {
+    progname = argv0;
+  } else {
+    progname += 1;
+  }
+  return progname;
+}
+
+
+extern "C" {
+  int prog_mruby(int argc, char **argv);
+  int prog_mirb(int argc, char **argv);
+}
+
 int main(int argc, char **argv) {
+  std::string name = progname(argv[0]);
+
+  if (name == "mruby") {
+    return prog_mruby(argc, argv);
+  } else if (name == "mirb") {
+    return prog_mirb(argc, argv);
+  }
+
   try {
     // Fix args on Windows to be UTF-8
     boost::nowide::args arg_utf8(argc, argv);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,14 +20,12 @@ include_directories(
   ${PROJECT_BINARY_DIR}/inc
   ${AUGEAS_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
-  ${YAMLCPP_INCLUDE_DIRS}
   ${LIBXML2_INCLUDE_DIRS}
   ${LEATHERMAN_INCLUDE_DIRS}
   ${MRUBY_INCLUDE_DIRS})
 
 link_directories(
-  ${Boost_LIBRARY_DIRS}
-  ${YAMLCPP_LIBRARY_DIRS})
+  ${Boost_LIBRARY_DIRS})
 
 set(PROJECT_SOURCES "src/libral.cc" "src/augeas/handle.cc" "src/augeas/node.cc"
   "src/ral.cc"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,7 +22,8 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
   ${YAMLCPP_INCLUDE_DIRS}
   ${LIBXML2_INCLUDE_DIRS}
-  ${LEATHERMAN_INCLUDE_DIRS})
+  ${LEATHERMAN_INCLUDE_DIRS}
+  ${MRUBY_INCLUDE_DIRS})
 
 link_directories(
   ${Boost_LIBRARY_DIRS}
@@ -41,19 +42,25 @@ set(PROJECT_SOURCES "src/libral.cc" "src/augeas/handle.cc" "src/augeas/node.cc"
   "src/emitter/puppet_emitter.cc"
   "src/emitter/json_emitter.cc")
 
-## An object target is generated that can be used by both the library and test executable targets.
-## Without the intermediate target, unexported symbols can't be tested.
+## An object target is generated that can be used by both the library and
+## test executable targets.  Without the intermediate target, unexported
+## symbols can't be tested.
 add_library(libprojectsrc OBJECT ${PROJECT_SOURCES})
 set_target_properties(libprojectsrc PROPERTIES POSITION_INDEPENDENT_CODE true)
 
 add_library(libral $<TARGET_OBJECTS:libprojectsrc>)
+add_dependencies(libral mruby)
 
 set(LIBVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+# We need to link to mruby before augeas, otherwise augeas picks up onigmo
+# regular expression routines, which leads to SEGV's in static builds
 set(LIBTARGETS
   ${LEATHERMAN_LIBRARIES}
   ${YAMLCPP_LIBRARIES}
   ${Boost_LIBRARIES}
+  ${MRUBY_LIBRARY}
   ${AUGEAS_LIBRARIES})
+
 target_link_libraries(libral ${LIBTARGETS})
 set_target_properties(libral PROPERTIES VERSION "${LIBVERSION}")
 
@@ -61,6 +68,7 @@ if (NOT LIBRAL_STATIC)
   # When we build against static libs, too many of them are built without
   # -fPIC and can not be linked into libral.so
   add_library(libral_shared SHARED $<TARGET_OBJECTS:libprojectsrc>)
+  add_dependencies(libral_shared mruby)
   set_target_properties(libral_shared PROPERTIES VERSION "${LIBVERSION}"
     OUTPUT_NAME libral PREFIX "" SUFFIX ".so")
   target_link_libraries(libral_shared ${LIBTARGETS})

--- a/lib/inc/libral/augeas/handle.hpp
+++ b/lib/inc/libral/augeas/handle.hpp
@@ -102,15 +102,13 @@ namespace libral { namespace augeas {
      * is none) and that lenses generally expect that newline to be there,
      * and otherwise might fail on non-newline terminated input.
      */
-    static std::shared_ptr<handle> make(const std::string& loadpath,
-                                        const callback& reader = nullptr,
+    static std::shared_ptr<handle> make(const callback& reader = nullptr,
                                         const callback& writer = nullptr) {
-      return std::shared_ptr<handle>(new handle(loadpath, reader, writer));
+      return std::shared_ptr<handle>(new handle(reader, writer));
     }
 
   private:
-    handle(const std::string& loadpath,
-           const callback& reader,
+    handle(const callback& reader,
            const callback &writer);
 
     /* Checks _augeas for errors and return an error if there is one. */

--- a/lib/inc/libral/environment.hpp
+++ b/lib/inc/libral/environment.hpp
@@ -56,7 +56,7 @@ namespace libral {
      */
     result<prov::spec> parse_spec(const std::string& name,
                                   const std::string& desc,
-                                  boost::optional<bool> suitable = boost::none);
+                                  bool suitable = true);
 
   protected:
     friend class ral;

--- a/lib/inc/libral/environment.hpp
+++ b/lib/inc/libral/environment.hpp
@@ -58,9 +58,6 @@ namespace libral {
                                   const std::string& desc,
                                   boost::optional<bool> suitable = boost::none);
 
-    result<prov::spec>
-    parse_spec(const std::string& name, const YAML::Node &node);
-
   protected:
     friend class ral;
 

--- a/lib/inc/libral/json_provider.hpp
+++ b/lib/inc/libral/json_provider.hpp
@@ -2,8 +2,6 @@
 
 #include "provider.hpp"
 
-#include <yaml-cpp/yaml.h>
-
 #include <leatherman/json_container/json_container.hpp>
 
 namespace libral {
@@ -14,8 +12,8 @@ namespace libral {
     using json_container = leatherman::json_container::JsonContainer;
     using json_keys = std::vector<leatherman::json_container::JsonContainerKey>;
 
-    json_provider(command::uptr& cmd, YAML::Node &node)
-      : provider(), _cmd(std::move(cmd)), _node(node) { };
+    json_provider(command::uptr& cmd, prov::spec &spec)
+      : provider(spec), _cmd(std::move(cmd)) { };
 
     result<std::vector<resource>>
     get(context& ctx, const std::vector<std::string>& names,
@@ -24,8 +22,6 @@ namespace libral {
     result<void> set(context &ctx, const updates& upds) override;
 
     const std::string& source() const override { return _cmd->path(); }
-  protected:
-    result<prov::spec> describe(environment &env) override;
   private:
     result<json_container>
     run_action(context& ctx,
@@ -45,6 +41,5 @@ namespace libral {
                     const json_keys& key);
 
     command::uptr _cmd;
-    YAML::Node    _node;
   };
 }

--- a/lib/inc/libral/mruby.hpp
+++ b/lib/inc/libral/mruby.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <libral/result.hpp>
+
+extern "C" {
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/class.h>
+#include <mruby/hash.h>
+#include <mruby/string.h>
+}
+
+namespace libral {
+
+  /**
+   * Simple wrapper to make accessing MRuby routines a bit more memory and
+   * type safe.
+   */
+  struct mruby {
+    mruby(mrb_state* mrb0)
+      : mrb(std::shared_ptr<mrb_state>(mrb0,
+                                       [](mrb_state *mrb) { mrb_close(mrb); }))
+    { }
+
+    using value = result<mrb_value>;
+
+    struct RClass *module_get(const std::string& name) {
+      return mrb_module_get(mrb.get(), name.c_str());
+    }
+
+    value str_new(const std::string& s) {
+      return check(mrb_str_new(mrb.get(), s.c_str(), s.length()));
+    }
+
+    value funcall(mrb_value obj, const std::string& name, mrb_value arg) {
+      return check(mrb_funcall(mrb.get(), obj, name.c_str(), 1, arg));
+    }
+
+    value funcall(struct RClass *rc, const std::string& name, mrb_value arg) {
+      return check(mrb_funcall(mrb.get(), mrb_obj_value(rc), name.c_str(), 1, arg));
+    }
+
+    value funcall(struct RClass *rc, const std::string& name,
+                  const std::string& arg) {
+      mrb_value s = mrb_str_new(mrb.get(), arg.c_str(), arg.length());
+      if (mrb->exc != nullptr) {
+        return error(_("Failed to make string"));
+      }
+      return check(mrb_funcall(mrb.get(), mrb_obj_value(rc), name.c_str(), 1, s));
+    }
+
+    void p(mrb_value v) { mrb_p(mrb.get(), v); }
+
+    mrb_int ary_len(mrb_value ary) {
+      return mrb_ary_len(mrb.get(), ary);
+    }
+
+    mrb_value hash_get(mrb_value hash, mrb_value key) {
+      return mrb_hash_get(mrb.get(), hash, key);
+    }
+
+    mrb_value hash_get(mrb_value hash, const std::string& key) {
+      mrb_value k = mrb_str_new(mrb.get(), key.c_str(), key.length());
+      return mrb_hash_get(mrb.get(), hash, k);
+    }
+
+    mrb_value hash_keys(mrb_value hash) {
+      return mrb_hash_keys(mrb.get(), hash);
+    }
+
+    bool bool_p(mrb_value v) {
+      // Surprisingly involved - can't find a simpler way to check
+      // whether v is the actual boolean value true or false
+      struct RClass *rc = mrb_class(mrb.get(), v);
+      return (rc == mrb->false_class || rc == mrb->true_class);
+    }
+
+    /**
+     * Returns the string value at key in hash. Returns dflt when hash is
+     * not a Hash, or does not contain a string at key
+     */
+    std::string hash_get_string(mrb_value hash, const std::string& key,
+                                const std::string& dflt = "") {
+      if (! mrb_hash_p(hash)) {
+        return dflt;
+      }
+      mrb_value k = mrb_str_new(mrb.get(), key.c_str(), key.length());
+      mrb_value v = mrb_hash_get(mrb.get(), hash, k);
+      if (mrb_nil_p(v) || ! mrb_string_p(v)) {
+        return dflt;
+      } else {
+        return std::string(RSTRING_PTR(v));
+      }
+    }
+
+    std::string as_string(mrb_value str, const std::string& dflt = "") {
+      if (mrb_string_p(str)) {
+        return std::string(RSTRING_PTR(str));
+      } else {
+        return dflt;
+      }
+    }
+
+    value check(const mrb_value& v) {
+      if (has_exc()) {
+        return exc_as_error();
+      }
+      return v;
+    }
+
+    bool has_exc() {
+      return (mrb->exc != nullptr);
+    }
+
+    error exc_as_error() {
+      if (mrb->exc != nullptr) {
+        mrb_value val = mrb_funcall(mrb.get(), mrb_obj_value(mrb->exc),
+                                    "message", 0);
+        mrb->exc = nullptr;
+        return error(std::string(RSTRING_PTR(val)));
+      } else {
+        return error("internal error: exc_as_error called even though there was no exception");
+      }
+    }
+
+    static result<mruby> open() {
+      mrb_state *mrb = mrb_open();
+      if (mrb == NULL) {
+        return error(_("Failed to open MRuby"));
+      }
+      return mruby(mrb);
+    }
+
+    std::shared_ptr<mrb_state> mrb;
+  };
+}

--- a/lib/inc/libral/prov/spec.hpp
+++ b/lib/inc/libral/prov/spec.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <boost/optional.hpp>
-#include <yaml-cpp/yaml.h>
 
 #include <libral/attr/spec.hpp>
 
@@ -37,7 +36,9 @@ namespace libral {
     /**
      * Returns the description of the provider
      */
-    const std::string& desc() const {return _desc; }
+    const std::string& desc() const { return _desc; }
+
+    const std::string& invoke() const { return _invoke; }
 
     /**
      * Returns true if the provider is suitable, i.e., can be used
@@ -46,16 +47,6 @@ namespace libral {
     bool suitable() const { return _suitable; }
 
     void suitable(bool s) { _suitable = s; }
-
-    /**
-     * Reads a provider specification from a parsed YAML representation
-     *
-     * @param name the provider name, used in error messages
-     * @param node the parsed YAML document
-     */
-    static result<spec> read(const libral::environment& env,
-                             const std::string& name,
-                             const YAML::Node &node);
 
     /**
      * Reads a provider specification from a string that must contain valid YAML
@@ -74,16 +65,14 @@ namespace libral {
 
   private:
     spec(const std::string& name, const std::string& type,
-         const std::string& desc, attr_spec_map&& attr_specs);
+         const std::string& desc, const std::string& invoke,
+         attr_spec_map&& attr_specs);
     std::string make_qname(const std::string& name, const std::string& type);
-
-    static result<bool>
-    read_suitable(const environment& env,
-                  const YAML::Node& node, const std::string& prov_name);
 
     std::string   _name;
     std::string   _type;
     std::string   _desc;
+    std::string   _invoke;
     std::string   _qname;
     bool          _suitable;
 

--- a/lib/inc/libral/prov/spec.hpp
+++ b/lib/inc/libral/prov/spec.hpp
@@ -46,17 +46,20 @@ namespace libral {
      */
     bool suitable() const { return _suitable; }
 
-    void suitable(bool s) { _suitable = s; }
-
     /**
      * Reads a provider specification from a string that must contain valid YAML
      *
+     * @param env the environment
      * @param name the provider name, used in error messages
      * @param yaml the YAML text
+     * @param suitable initial indication of suitability; the provider is
+     *                 ultimately suitable if this flag is true and the
+     *                 metadata indicates that it is suitable
      */
     static result<spec> read(const libral::environment &env,
                              const std::string& name,
-                             const std::string &yaml);
+                             const std::string &yaml,
+                             bool suitable);
 
     attr_spec_map::const_iterator attr_begin() const
       { return _attr_specs.cbegin(); }
@@ -66,6 +69,7 @@ namespace libral {
   private:
     spec(const std::string& name, const std::string& type,
          const std::string& desc, const std::string& invoke,
+         bool suitable,
          attr_spec_map&& attr_specs);
     std::string make_qname(const std::string& name, const std::string& type);
 

--- a/lib/inc/libral/provider.hpp
+++ b/lib/inc/libral/provider.hpp
@@ -29,6 +29,8 @@ namespace libral {
   class provider : public std::enable_shared_from_this<provider> {
   public:
     provider() { };
+    provider(prov::spec& spec) : _spec(spec) { }
+
     virtual ~provider() = default;
 
     /**
@@ -146,7 +148,7 @@ namespace libral {
      * do any provider-internal initialization and check whether the
      * provider is suitable for this system.
      */
-    virtual result<prov::spec> describe(environment &env) = 0;
+    virtual result<prov::spec> describe(environment &env);
   private:
     /* This gets only intitialized when we call prepare, and we therefore
      * must allow for it to be none for a while

--- a/lib/inc/libral/ral.hpp
+++ b/lib/inc/libral/ral.hpp
@@ -4,8 +4,6 @@
 #include <memory>
 #include <boost/optional.hpp>
 
-#include <yaml-cpp/yaml.h>
-
 #include <libral/result.hpp>
 #include <libral/provider.hpp>
 #include <libral/environment.hpp>
@@ -46,8 +44,6 @@ namespace libral {
     bool init_provider(environment &env,
                        const std::string& name,
                        std::shared_ptr<provider>& prov);
-    result<YAML::Node> parse_metadata(const std::string& path,
-                                      const std::string& yaml) const;
     result<std::string> get_metadata(command& cmd, const std::string& path) const;
     result<std::string> run_describe(command& cmd) const;
 

--- a/lib/inc/libral/simple_provider.hpp
+++ b/lib/inc/libral/simple_provider.hpp
@@ -2,15 +2,13 @@
 
 #include "provider.hpp"
 
-#include <yaml-cpp/yaml.h>
-
 namespace libral {
   /* A provider backed by an executable that follows the 'simple' calling
      convention */
   class simple_provider : public provider {
   public:
-    simple_provider(command::uptr& cmd, YAML::Node &node)
-      : provider(), _cmd(std::move(cmd)), _node(node) { };
+    simple_provider(command::uptr& cmd, prov::spec& spec)
+      : provider(spec), _cmd(std::move(cmd)) { };
 
     result<std::vector<resource>>
     get(context &ctx,
@@ -20,8 +18,6 @@ namespace libral {
     result<void> set(context &ctx, const updates& upds) override;
 
     const std::string& source() const override { return _cmd->path(); }
-  protected:
-    result<prov::spec> describe(environment &env) override;
   private:
     result<std::vector<resource>> find(context& ctx, const std::string &name);
     result<std::vector<resource>> instances(context& ctx);
@@ -32,6 +28,5 @@ namespace libral {
                std::vector<std::string> args = {});
 
     command::uptr _cmd;
-    YAML::Node    _node;
   };
 }

--- a/lib/inc/libral/target/base.hpp
+++ b/lib/inc/libral/target/base.hpp
@@ -41,8 +41,7 @@ namespace libral {
      * file. Note that globs in filenames are currently not supported.
      */
     virtual result<std::shared_ptr<augeas::handle>>
-    augeas(const std::vector<std::string>& data_dirs,
-           const std::vector<std::pair<std::string, std::string>>& xfms) = 0;
+    augeas(const std::vector<std::pair<std::string, std::string>>& xfms) = 0;
 
     /**
      * Returns true if file is executable

--- a/lib/inc/libral/target/local.hpp
+++ b/lib/inc/libral/target/local.hpp
@@ -13,8 +13,7 @@ namespace libral {
     libral::command::uptr script(const std::string& cmd) override;
 
     result<std::shared_ptr<augeas::handle>>
-    augeas(const std::vector<std::string>& data_dirs,
-           const std::vector<std::pair<std::string, std::string>>& xfms) override;
+    augeas(const std::vector<std::pair<std::string, std::string>>& xfms) override;
 
     bool executable(const std::string& file) override;
 

--- a/lib/inc/libral/target/ssh.hpp
+++ b/lib/inc/libral/target/ssh.hpp
@@ -18,8 +18,7 @@ namespace libral {
     libral::command::uptr script(const std::string& cmd) override;
 
     result<std::shared_ptr<augeas::handle>>
-    augeas(const std::vector<std::string>& data_dirs,
-           const std::vector<std::pair<std::string, std::string>>& xfms)
+    augeas(const std::vector<std::pair<std::string, std::string>>& xfms)
       override;
 
     bool executable(const std::string& file) override;

--- a/lib/src/augeas/handle.cc
+++ b/lib/src/augeas/handle.cc
@@ -10,8 +10,7 @@ using namespace leatherman::locale;
 
 namespace libral { namespace augeas {
 
-  handle::handle(const std::string& loadpath,
-         const callback& reader, const callback &writer)
+  handle::handle(const callback& reader, const callback &writer)
     : _reader(reader), _writer(writer) {
     // We do not report errors from aug_init. That's bad. Very bad.
 
@@ -19,7 +18,7 @@ namespace libral { namespace augeas {
     // write ourselves with aug_load or aug_save
     const char *root = (_reader != nullptr || _writer != nullptr)
       ? "/dev/null" : NULL;
-    _augeas = aug_init(root, loadpath.c_str(), AUG_NO_MODL_AUTOLOAD);
+    _augeas = aug_init(root, nullptr, AUG_NO_MODL_AUTOLOAD);
 
     // Set up default reader and writer
     if (_reader == nullptr) {

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -30,7 +30,7 @@ namespace libral {
 
   result<std::shared_ptr<augeas::handle>>
   environment::augeas(const std::vector<std::pair<std::string, std::string>>& xfms) {
-    return _ral->target()->augeas(data_dirs(), xfms);
+    return _ral->target()->augeas(xfms);
   }
 
   result<prov::spec>

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -36,13 +36,7 @@ namespace libral {
   result<prov::spec>
   environment::parse_spec(const std::string& name,
                           const std::string& desc,
-                          boost::optional<bool> suitable) {
-
-    auto spec = prov::spec::read(*this, name, desc);
-    err_ret(spec);
-
-    if (suitable)
-      spec.ok().suitable(*suitable);
-    return spec;
+                          bool suitable) {
+    return prov::spec::read(*this, name, desc, suitable);
   }
 }

--- a/lib/src/environment.cc
+++ b/lib/src/environment.cc
@@ -45,9 +45,4 @@ namespace libral {
       spec.ok().suitable(*suitable);
     return spec;
   }
-
-  result<prov::spec>
-  environment::parse_spec(const std::string& name, const YAML::Node &node) {
-    return prov::spec::read(*this, name, node);
-  }
 }

--- a/lib/src/group.yaml
+++ b/lib/src/group.yaml
@@ -5,6 +5,8 @@ provider:
   type: group
   desc: |
     Manage groups with groupadd/groupmod/groupdel
+  suitable:
+    commands: [groupadd, groupdel, groupmod]
   attributes:
     name:
       desc: the groupname

--- a/lib/src/host.cc
+++ b/lib/src/host.cc
@@ -13,7 +13,7 @@ namespace libral {
 
     _aug = aug.ok();
 
-    return env.parse_spec("host", desc, true);
+    return env.parse_spec("host", desc);
   }
 
   result<aug::node>

--- a/lib/src/host.yaml
+++ b/lib/src/host.yaml
@@ -5,6 +5,7 @@ provider:
   type: host
   desc: |
     Manage mount points using the mount command on Linux.
+  suitable: true
   attributes:
     name:
       desc: the host name

--- a/lib/src/json_provider.cc
+++ b/lib/src/json_provider.cc
@@ -125,12 +125,6 @@ namespace libral {
     return result<void>();
   }
 
-  result<prov::spec> json_provider::describe(environment &env) {
-    auto name = fs::path(_cmd->path()).filename().stem();
-
-    return env.parse_spec(name.native(), _node);
-  }
-
   result<std::vector<resource>>
   json_provider::get(context &ctx,
                      const std::vector<std::string>& names,

--- a/lib/src/mount.cc
+++ b/lib/src/mount.cc
@@ -24,9 +24,7 @@ namespace libral {
     _cmd_mount = env.command("mount");
     _cmd_umount = env.command("umount");
 
-    auto suitable = _cmd_mount && _cmd_umount;
-
-    return env.parse_spec("mount", desc, suitable);
+    return env.parse_spec("mount", desc);
   }
 
   aug::node mount_provider::base(const update &upd) {

--- a/lib/src/mount.yaml
+++ b/lib/src/mount.yaml
@@ -5,6 +5,8 @@ provider:
   type: mount
   desc: |
     Manage mount points using the mount command on Linux.
+  suitable:
+    commands: [mount, umount]
   attributes:
     name:
       desc: the mount point

--- a/lib/src/provider.cc
+++ b/lib/src/provider.cc
@@ -90,11 +90,20 @@ namespace libral {
     return s_builtin;
   }
 
-  result<void> provider::prepare(environment &env) {
-    auto res = describe(env);
-    err_ret(res);
+  result<prov::spec> provider::describe(environment &env) {
+    if (!_spec) {
+      return error(_("Internal error: spec should have been given in the constructor"));
+    }
+    return *_spec;
+  }
 
-    _spec = res.ok();
+  result<void> provider::prepare(environment &env) {
+    if (! _spec) {
+      auto res = describe(env);
+      err_ret(res);
+
+      _spec = res.ok();
+    }
     return result<void>();
   }
 

--- a/lib/src/ral.cc
+++ b/lib/src/ral.cc
@@ -45,6 +45,30 @@ namespace libral {
     return environment(shared_from_this());
   }
 
+  void update_augeas_lens_lib(const std::vector<std::string>& data_dirs) {
+    // Append our lenses to AUGEAS_LENS_LIB. We do this in the environment
+    // rather than when we construct augeas handles because that ensures
+    // that external providers also use that setting
+    const std::string var = "AUGEAS_LENS_LIB";
+
+    std::stringstream buf;
+    bool first=true;
+
+    for (auto dir : data_dirs) {
+      if (!first)
+        buf << ":";
+      first=false;
+      buf << dir << "/lenses";
+    }
+
+    std::string value;
+    if (util::environment::get(var, value)) {
+      util::environment::set(var, value + ":" + buf.str());
+    } else {
+      util::environment::set(var, buf.str());
+    }
+  }
+
   std::shared_ptr<ral> ral::create(std::vector<std::string> data_dirs) {
     std::string env_data_dir;
 
@@ -84,6 +108,8 @@ namespace libral {
     util::environment::reload_search_paths();
 
     // FIXME: Check that mruby is there and warn otherwise
+
+    update_augeas_lens_lib(data_dirs);
 
     auto handle = new ral(data_dirs);
 

--- a/lib/src/simple_provider.cc
+++ b/lib/src/simple_provider.cc
@@ -61,12 +61,6 @@ namespace libral {
     return result<void>();
   }
 
-  result<prov::spec> simple_provider::describe(environment &env) {
-    auto name = fs::path(_cmd->path()).filename().stem();
-
-    return env.parse_spec(name.native(), _node);
-  }
-
   result<std::vector<resource>>
   simple_provider::get(context &ctx,
       const std::vector<std::string>& names,

--- a/lib/src/target/local.cc
+++ b/lib/src/target/local.cc
@@ -32,19 +32,8 @@ namespace libral {
   }
 
   result<std::shared_ptr<augeas::handle>>
-  local::augeas(const std::vector<std::string>& data_dirs,
-                const std::vector<std::pair<std::string, std::string>>& xfms) {
-    std::stringstream buf;
-    bool first=true;
-
-    for (auto dir : data_dirs) {
-      if (!first)
-        buf << ":";
-      first=false;
-      buf << dir << "/lenses";
-    }
-
-    auto aug = aug::handle::make(buf.str());
+  local::augeas(const std::vector<std::pair<std::string, std::string>>& xfms) {
+    auto aug = aug::handle::make();
     for (auto& xfm : xfms) {
       err_ret( aug->include(xfm.first, xfm.second) );
     }

--- a/lib/src/target/ssh.cc
+++ b/lib/src/target/ssh.cc
@@ -27,19 +27,7 @@ namespace libral {
   }
 
   result<std::shared_ptr<augeas::handle>>
-  ssh::augeas(const std::vector<std::string>& data_dirs,
-              const std::vector<std::pair<std::string, std::string>>& xfms) {
-
-    std::stringstream buf;
-    bool first=true;
-
-    for (auto dir : data_dirs) {
-      if (!first)
-        buf << ":";
-      first=false;
-      buf << dir << "/lenses";
-    }
-
+  ssh::augeas(const std::vector<std::pair<std::string, std::string>>& xfms) {
     auto reader = [xfms, this](::augeas* aug) {
       for (auto& xfm : xfms) {
         auto res = read(xfm.second);
@@ -81,7 +69,7 @@ namespace libral {
       }
     };
 
-    auto aug = aug::handle::make(buf.str(), reader, writer);
+    auto aug = aug::handle::make(reader, writer);
     err_ret( aug->load() );
 
     return aug;

--- a/lib/src/user.yaml
+++ b/lib/src/user.yaml
@@ -5,6 +5,8 @@ provider:
   type: user
   desc: |
     Manage users with useradd/usermod/userdel
+  suitable:
+    commands: [useradd, usermod, userdel]
   attributes:
     name:
       desc: the username

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -8,11 +8,6 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/fixtures.hpp.in"
 set(TEST_CASES file.cc ${PROJECT_NAME}.cc json_provider.cc)
 
 add_executable(libral_test $<TARGET_OBJECTS:libprojectsrc> ${TEST_CASES} fixtures.cc attr/spec.cc main.cc)
-target_link_libraries(libral_test
-    ${LEATHERMAN_LIBRARIES}
-    ${YAMLCPP_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${AUGEAS_LIBRARIES}
-)
+target_link_libraries(libral_test libral)
 
 add_test(NAME "unit_tests" COMMAND libral_test)

--- a/mruby/CMakeLists.txt
+++ b/mruby/CMakeLists.txt
@@ -9,6 +9,11 @@ set(MRUBY_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/mruby-${MRUBY_VERSION}")
 
 set(MRUBY_SOURCE_DIR "${PROJECT_SOURCE_DIR}/mruby")
 
+# We should really process mruby/host/lib/libmruby.flags.mak and pull that
+# out of there
+set(MRUBY_INCLUDE_DIRS "${MRUBY_SOURCES}/include" CACHE INTERNAL "")
+set(MRUBY_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/host/lib/libmruby.a;${CMAKE_CURRENT_BINARY_DIR}/host/mrbgems/mruby-yaml/yaml-0.1.7/build/lib/libyaml.a" CACHE INTERNAL "")
+
 add_custom_command(COMMENT "Unpack mruby"
   OUTPUT "${MRUBY_SOURCES}"
   DEPENDS "${MRUBY_TARBALL}"
@@ -34,8 +39,6 @@ add_custom_command(OUTPUT "${MRUBY}"
 add_custom_target("mruby" DEPENDS "${MRUBY}")
 
 add_dependencies(mruby mruby_unpack)
-
-add_dependencies(libral mruby)
 
 set(CLEAN_FILES "${PROJECT_BINARY_DIR}/mruby/host"
   "${PROJECT_BINARY_DIR}/bin/mirb"

--- a/mruby/CMakeLists.txt
+++ b/mruby/CMakeLists.txt
@@ -12,7 +12,7 @@ set(MRUBY_SOURCE_DIR "${PROJECT_SOURCE_DIR}/mruby")
 # We should really process mruby/host/lib/libmruby.flags.mak and pull that
 # out of there
 set(MRUBY_INCLUDE_DIRS "${MRUBY_SOURCES}/include" CACHE INTERNAL "")
-set(MRUBY_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/host/lib/libmruby.a;${CMAKE_CURRENT_BINARY_DIR}/host/mrbgems/mruby-yaml/yaml-0.1.7/build/lib/libyaml.a" CACHE INTERNAL "")
+set(MRUBY_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/host/lib/libmruby.a;${CMAKE_CURRENT_BINARY_DIR}/host/mrbgems/mruby-yaml/yaml-0.1.7/build/lib/libyaml.a;dl" CACHE INTERNAL "")
 
 add_custom_command(COMMENT "Unpack mruby"
   OUTPUT "${MRUBY_SOURCES}"
@@ -30,6 +30,7 @@ configure_file("${PROJECT_SOURCE_DIR}/mruby/build_config.rb.in"
 add_custom_command(OUTPUT "${MRUBY}"
   COMMENT "Build mruby"
   DEPENDS "${MRUBY_TARBALL}" "${PROJECT_BINARY_DIR}/mruby/build_config.rb"
+          "${MRUBY_SOURCE_DIR}/libral.gembox"
   WORKING_DIRECTORY "${MRUBY_SOURCES}"
   COMMAND "rake"
           "MRUBY_BUILD_DIR=${PROJECT_BINARY_DIR}/mruby"

--- a/mruby/build_config.rb.in
+++ b/mruby/build_config.rb.in
@@ -19,7 +19,7 @@ module Libral
 
   # Whether to enable or disable readline in static builds of mirb
   # For now, we always enable it as that's a little friendlier to users.
-  ENABLE_READLINE = false
+  ENABLE_READLINE = true
 end
 
 def libral_configure_mruby_augeas(gem)

--- a/mruby/build_config.rb.in
+++ b/mruby/build_config.rb.in
@@ -63,7 +63,7 @@ MRuby::Build.new do |conf|
     cc.flags << "-fPIC"
   end
   conf.cxx.command = Libral::CXX
-  conf.cxx.flags = Libral::CXX_FLAGS
+  conf.cxx.flags = Libral::CXX_FLAGS + ["-fPIC"]
   # mruby core has some implicit fallthroughs in vm.c
   conf.cxx.flags << "-Wno-implicit-fallthrough"
   conf.linker.command = Libral::CXX

--- a/mruby/libral.gembox
+++ b/mruby/libral.gembox
@@ -89,6 +89,9 @@ MRuby::GemBox.new do |conf|
   # JSON parser and generator
   conf.gem :github => 'iij/mruby-iijson'
 
+  # File.fnmatch() & Dir.glob()
+  conf.gem :github => 'gromnitsky/mruby-dir-glob'
+
   # YAML parser
   conf.gem :github => "lutter/mruby-yaml", :branch => "upd" do |g|
     # libyaml is pretty unclean when we build it - suppress

--- a/mruby/libral.gembox
+++ b/mruby/libral.gembox
@@ -111,6 +111,9 @@ MRuby::GemBox.new do |conf|
   # Onigmo regular expressions
   conf.gem :github => 'mattn/mruby-onig-regexp'
 
+  # ENV access
+  conf.gem :github => 'iij/mruby-env'
+
   # Bindings to augeas
   conf.gem :github => "hercules-team/mruby-augeas" do |g|
     libral_configure_mruby_augeas(g)

--- a/mruby/libral.gembox
+++ b/mruby/libral.gembox
@@ -74,6 +74,9 @@ MRuby::GemBox.new do |conf|
   # Generate mruby-strip command
   conf.gem :core => "mruby-bin-strip"
 
+  # Generate mrbc command
+  conf.gem :core => "mruby-bin-mrbc"
+
   # Use Kernel module extension
   conf.gem :core => "mruby-kernel-ext"
 
@@ -118,5 +121,5 @@ MRuby::GemBox.new do |conf|
 
   # Any GEM after this one will be built as a DSO
   # busted with 1.3.0
-  #conf.gem :github => 'mattn/mruby-require'
+  conf.gem :github => 'mattn/mruby-require'
 end


### PR DESCRIPTION
We now link mruby into libral, and use it for parsing yaml to avoid the dependency on yaml-cpp.

This is the first step in making mruby much more central to libral; in the future, more parts of libral will be written in mruby instead of C++.